### PR TITLE
Event replay functionality and epoch db eviction

### DIFF
--- a/.github/workflows/push-docker-bob-events-bridge-dev.yaml
+++ b/.github/workflows/push-docker-bob-events-bridge-dev.yaml
@@ -3,7 +3,7 @@ name: Create bob events bridge dev image
 on:
   push:
     branches:
-      - 33-oracle-log-types
+      - 34-epoch-archive
     paths:
       - 'bob-events-bridge/**'
       - '.github/workflows/push-docker-bob-events-bridge-dev.yaml'
@@ -53,4 +53,4 @@ jobs:
           context: ./bob-events-bridge
           file: ./bob-events-bridge/Dockerfile
           push: true
-          tags: ghcr.io/qubic/bob-events-bridge:33-oracle-log-types
+          tags: ghcr.io/qubic/bob-events-bridge:34-epoch-archive

--- a/bob-events-bridge/Dockerfile
+++ b/bob-events-bridge/Dockerfile
@@ -5,10 +5,12 @@ WORKDIR /src
 COPY . /src
 
 RUN go build -o "./bin/events-bridge" "./cmd/events-bridge"
+RUN go build -o "./bin/events-replay" "./cmd/events-replay"
 
 # We don't need golang to run binaries, just use alpine.
 FROM alpine
 COPY --from=builder /src/bin/events-bridge /app/events-bridge
+COPY --from=builder /src/bin/events-replay /app/events-replay
 
 EXPOSE 8000
 EXPOSE 8001

--- a/bob-events-bridge/cmd/events-bridge/main.go
+++ b/bob-events-bridge/cmd/events-bridge/main.go
@@ -34,6 +34,8 @@ func main() {
 
 	// Setup logger
 	logConfig := zap.NewProductionConfig()
+	logConfig.Encoding = "console"
+	logConfig.EncoderConfig.EncodeTime = zapcore.TimeEncoderOfLayout(time.DateTime)
 	if cfg.Debug {
 		logConfig.Level = zap.NewAtomicLevelAt(zapcore.DebugLevel)
 	}

--- a/bob-events-bridge/cmd/events-bridge/main.go
+++ b/bob-events-bridge/cmd/events-bridge/main.go
@@ -68,7 +68,7 @@ func main() {
 	bridgeMetrics := metrics.NewBridgeMetrics(promReg, cfg.Metrics.Namespace)
 
 	// Initialize storage manager
-	storageMgr, err := storage.NewManager(cfg.Storage.BasePath, logger)
+	storageMgr, err := storage.NewManager(cfg.Storage.BasePath, cfg.Storage.KeepEpochs, logger)
 	if err != nil {
 		logger.Fatal("Failed to initialize storage", zap.Error(err))
 	}

--- a/bob-events-bridge/cmd/events-replay/main.go
+++ b/bob-events-bridge/cmd/events-replay/main.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+
+	grpcProm "github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/qubic/bob-events-bridge/internal/config"
+	bridgeGrpc "github.com/qubic/bob-events-bridge/internal/grpc"
+	"github.com/qubic/bob-events-bridge/internal/kafka"
+	"github.com/qubic/bob-events-bridge/internal/metrics"
+	"github.com/qubic/bob-events-bridge/internal/storage"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	googleGrpc "google.golang.org/grpc"
+)
+
+func main() {
+	cfg, err := config.Parse()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to parse configuration: %v\n", err)
+		os.Exit(1)
+	}
+
+	if err := validateReplayConfig(cfg); err != nil {
+		fmt.Fprintf(os.Stderr, "Invalid replay configuration: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Setup logger
+	logConfig := zap.NewProductionConfig()
+	if cfg.Debug {
+		logConfig.Level = zap.NewAtomicLevelAt(zapcore.DebugLevel)
+	}
+	logger, err := logConfig.Build()
+	if err != nil {
+		panic("failed to create logger: " + err.Error())
+	}
+	defer logger.Sync() //nolint:errcheck
+
+	logger.Info("Starting bob-events-bridge REPLAY",
+		zap.String("version", config.Version),
+		zap.String("build", config.Build))
+
+	promReg := prometheus.DefaultRegisterer
+
+	grpcMetrics := grpcProm.NewServerMetrics(
+		grpcProm.WithServerCounterOptions(grpcProm.WithConstLabels(prometheus.Labels{"namespace": cfg.Metrics.Namespace})),
+	)
+	promReg.MustRegister(grpcMetrics)
+
+	bridgeMetrics := metrics.NewBridgeMetrics(promReg, cfg.Metrics.Namespace)
+
+	// Initialize storage manager
+	storageMgr, err := storage.NewManager(cfg.Storage.BasePath, cfg.Storage.KeepEpochs, logger)
+	if err != nil {
+		logger.Fatal("Failed to initialize storage", zap.Error(err))
+	}
+	defer storageMgr.Close() //nolint:errcheck
+
+	logger.Info("Storage initialized",
+		zap.Strings("epochs", epochsToStrings(storageMgr.GetAvailableEpochs())))
+
+	if cfg.Replay.EnableServer {
+		// Create and start gRPC server
+		server := bridgeGrpc.NewServer(storageMgr, logger,
+			googleGrpc.UnaryInterceptor(grpcMetrics.UnaryServerInterceptor()),
+			googleGrpc.StreamInterceptor(grpcMetrics.StreamServerInterceptor()),
+		)
+		if err := server.Start(bridgeGrpc.ServerConfig{
+			GRPCAddr: cfg.Server.GRPCAddr,
+			HTTPAddr: cfg.Server.HTTPAddr,
+		}); err != nil {
+			logger.Fatal("Failed to start server", zap.Error(err))
+		}
+
+		logger.Info("gRPC and HTTP servers started")
+	}
+
+	if cfg.Replay.EnablePublish {
+		db := storageMgr.GetEpochDB(uint32(cfg.Replay.Epoch))
+		if db == nil {
+			logger.Fatal("Replay epoch not found in storage",
+				zap.Uint16("epoch", cfg.Replay.Epoch),
+				zap.Strings("available", epochsToStrings(storageMgr.GetAvailableEpochs())))
+		}
+
+		brokers := strings.Split(cfg.Kafka.Brokers, ",")
+		producer, err := kafka.NewProducer(
+			brokers,
+			cfg.Kafka.Topic,
+			logger,
+			bridgeMetrics,
+			prometheus.DefaultRegisterer,
+			prometheus.DefaultGatherer,
+			cfg.Metrics.Namespace,
+		)
+		if err != nil {
+			logger.Fatal("Failed to create Kafka producer", zap.Error(err))
+		}
+		defer producer.Close() //nolint:errcheck
+
+		logger.Info("Kafka publisher enabled",
+			zap.Strings("brokers", brokers),
+			zap.String("topic", cfg.Kafka.Topic))
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		if _, err := runReplay(ctx, db, producer, cfg.Replay.TickStart, cfg.Replay.TickEnd, logger); err != nil {
+			logger.Fatal("Replay failed", zap.Error(err))
+		}
+	}
+
+	if cfg.Replay.EnableServer {
+		// Block until interrupted; gRPC/HTTP keep serving.
+		sigCh := make(chan os.Signal, 1)
+		signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+		sig := <-sigCh
+		logger.Info("Shutting down", zap.String("signal", sig.String()))
+	}
+}
+
+// validateReplayConfig enforces flag combinations that must hold before any
+// expensive setup runs. Fails fast with a clear message rather than failing
+// later in storage/kafka init.
+func validateReplayConfig(cfg *config.Config) error {
+	if !cfg.Replay.EnableServer && !cfg.Replay.EnablePublish {
+		return fmt.Errorf("at least one of Replay.EnableServer or Replay.EnablePublish must be true")
+	}
+	if cfg.Replay.EnablePublish {
+		if !cfg.Kafka.Enabled {
+			return fmt.Errorf("Replay.EnablePublish=true requires Kafka.Enabled=true")
+		}
+		if strings.TrimSpace(cfg.Kafka.Brokers) == "" {
+			return fmt.Errorf("Replay.EnablePublish=true requires Kafka.Brokers to be set")
+		}
+	}
+	if cfg.Replay.TickEnd != 0 && cfg.Replay.TickEnd < cfg.Replay.TickStart {
+		return fmt.Errorf("Replay.TickEnd (%d) must be >= Replay.TickStart (%d)",
+			cfg.Replay.TickEnd, cfg.Replay.TickStart)
+	}
+	return nil
+}
+
+func epochsToStrings(epochs []uint32) []string {
+	result := make([]string, len(epochs))
+	for i, e := range epochs {
+		result[i] = fmt.Sprintf("%d", e)
+	}
+	return result
+}

--- a/bob-events-bridge/cmd/events-replay/replay.go
+++ b/bob-events-bridge/cmd/events-replay/replay.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	eventsbridge "github.com/qubic/bob-events-bridge/api/events-bridge/v1"
+	"github.com/qubic/bob-events-bridge/internal/kafka"
+	"github.com/qubic/bob-events-bridge/internal/storage"
+	"go.uber.org/zap"
+)
+
+const replayProgressTickInterval = 100
+
+// runReplay iterates events in [tickStart, tickEnd] from db, builds Kafka messages,
+// and publishes them in per-tick batches (mirrors processor.flushBatch behavior).
+// Returns the total number of events published.
+func runReplay(
+	ctx context.Context,
+	db *storage.EpochDB,
+	publisher kafka.Publisher,
+	tickStart, tickEnd uint32,
+	logger *zap.Logger,
+) (uint64, error) {
+	logger.Info("Replay starting",
+		zap.Uint32("epoch", db.Epoch()),
+		zap.Uint32("tickStart", tickStart),
+		zap.Uint32("tickEnd", tickEnd))
+
+	var (
+		published    uint64
+		ticksFlushed uint64
+		batch        []*kafka.EventMessage
+		batchTick    uint32
+	)
+
+	flush := func() error {
+		if len(batch) == 0 {
+			return nil
+		}
+		if err := publisher.PublishEvents(ctx, batch); err != nil {
+			return fmt.Errorf("failed to publish batch for tick %d: %w", batchTick, err)
+		}
+		published += uint64(len(batch))
+		ticksFlushed++
+		if ticksFlushed%replayProgressTickInterval == 0 {
+			logger.Info("Replay progress",
+				zap.Uint64("ticksFlushed", ticksFlushed),
+				zap.Uint64("eventsPublished", published),
+				zap.Uint32("currentTick", batchTick))
+		}
+		batch = batch[:0]
+		return nil
+	}
+
+	err := db.IterateEventsInRange(tickStart, tickEnd, func(event *eventsbridge.Event) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		if len(batch) > 0 && event.Tick != batchTick {
+			if err := flush(); err != nil {
+				return err
+			}
+		}
+
+		msg, err := kafka.BuildEventMessageFromStored(event)
+		if err != nil {
+			return fmt.Errorf("failed to build kafka message for tick %d log %d: %w",
+				event.Tick, event.LogId, err)
+		}
+
+		batch = append(batch, msg)
+		batchTick = event.Tick
+		return nil
+	})
+	if err != nil {
+		return published, fmt.Errorf("replay iteration failed: %w", err)
+	}
+
+	if err := flush(); err != nil {
+		return published, err
+	}
+
+	logger.Info("Replay complete",
+		zap.Uint32("epoch", db.Epoch()),
+		zap.Uint64("ticksFlushed", ticksFlushed),
+		zap.Uint64("eventsPublished", published))
+
+	return published, nil
+}

--- a/bob-events-bridge/cmd/events-replay/replay_test.go
+++ b/bob-events-bridge/cmd/events-replay/replay_test.go
@@ -1,0 +1,174 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	eventsbridge "github.com/qubic/bob-events-bridge/api/events-bridge/v1"
+	"github.com/qubic/bob-events-bridge/internal/bob"
+	"github.com/qubic/bob-events-bridge/internal/kafka"
+	"github.com/qubic/bob-events-bridge/internal/storage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// makeQuTransferEvent builds an Event in stored (bob) body format.
+func makeQuTransferEvent(t *testing.T, tick uint32, logID uint64, indexInTick uint32, last bool) *eventsbridge.Event {
+	t.Helper()
+	body, err := structpb.NewStruct(map[string]any{
+		"from":   "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"to":     "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+		"amount": float64(logID * 10),
+	})
+	require.NoError(t, err)
+	return &eventsbridge.Event{
+		LogId:          logID,
+		Tick:           tick,
+		Epoch:          1,
+		EventType:      bob.LogTypeQuTransfer,
+		TxHash:         "TXHASH",
+		Timestamp:      1718461800,
+		Body:           body,
+		IndexInTick:    indexInTick,
+		LogDigest:      "digest",
+		LastLogForTick: last,
+	}
+}
+
+func openTestDB(t *testing.T) *storage.EpochDB {
+	t.Helper()
+	db, err := storage.NewEpochDB(t.TempDir(), 1)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func TestRunReplay_FullEpoch(t *testing.T) {
+	db := openTestDB(t)
+
+	// Three ticks, each with 2 events.
+	require.NoError(t, db.StoreEvent(makeQuTransferEvent(t, 100, 1, 0, false)))
+	require.NoError(t, db.StoreEvent(makeQuTransferEvent(t, 100, 2, 1, true)))
+	require.NoError(t, db.StoreEvent(makeQuTransferEvent(t, 200, 3, 0, false)))
+	require.NoError(t, db.StoreEvent(makeQuTransferEvent(t, 200, 4, 1, true)))
+	require.NoError(t, db.StoreEvent(makeQuTransferEvent(t, 300, 5, 0, true)))
+
+	pub := kafka.NewMockPublisher()
+
+	n, err := runReplay(context.Background(), db, pub, 0, 0, zap.NewNop())
+	require.NoError(t, err)
+	assert.Equal(t, uint64(5), n)
+
+	msgs := pub.Messages()
+	require.Len(t, msgs, 5)
+
+	// Order preserved (ascending tick, ascending key within tick).
+	assert.Equal(t, []uint32{100, 100, 200, 200, 300}, []uint32{
+		msgs[0].TickNumber, msgs[1].TickNumber, msgs[2].TickNumber, msgs[3].TickNumber, msgs[4].TickNumber,
+	})
+
+	// Body must be transformed to kafka format.
+	assert.Equal(t, "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", msgs[0].Body["source"])
+	assert.NotContains(t, msgs[0].Body, "from")
+
+	// BodySize=0 on replay
+	for _, m := range msgs {
+		assert.Equal(t, uint32(0), m.BodySize)
+	}
+}
+
+func TestRunReplay_TickRange(t *testing.T) {
+	db := openTestDB(t)
+
+	require.NoError(t, db.StoreEvent(makeQuTransferEvent(t, 100, 1, 0, true)))
+	require.NoError(t, db.StoreEvent(makeQuTransferEvent(t, 200, 2, 0, true)))
+	require.NoError(t, db.StoreEvent(makeQuTransferEvent(t, 300, 3, 0, true)))
+	require.NoError(t, db.StoreEvent(makeQuTransferEvent(t, 400, 4, 0, true)))
+
+	pub := kafka.NewMockPublisher()
+
+	n, err := runReplay(context.Background(), db, pub, 200, 300, zap.NewNop())
+	require.NoError(t, err)
+	assert.Equal(t, uint64(2), n)
+
+	msgs := pub.Messages()
+	require.Len(t, msgs, 2)
+	assert.Equal(t, uint32(200), msgs[0].TickNumber)
+	assert.Equal(t, uint32(300), msgs[1].TickNumber)
+}
+
+func TestRunReplay_EmptyDB(t *testing.T) {
+	db := openTestDB(t)
+	pub := kafka.NewMockPublisher()
+
+	n, err := runReplay(context.Background(), db, pub, 0, 0, zap.NewNop())
+	require.NoError(t, err)
+	assert.Equal(t, uint64(0), n)
+	assert.Empty(t, pub.Messages())
+}
+
+func TestRunReplay_PublisherErrorPropagates(t *testing.T) {
+	db := openTestDB(t)
+	require.NoError(t, db.StoreEvent(makeQuTransferEvent(t, 100, 1, 0, false)))
+	require.NoError(t, db.StoreEvent(makeQuTransferEvent(t, 200, 2, 0, true)))
+
+	pub := kafka.NewMockPublisher()
+	pub.SetFailNext(errors.New("kafka boom"))
+
+	_, err := runReplay(context.Background(), db, pub, 0, 0, zap.NewNop())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to publish batch")
+}
+
+func TestRunReplay_ContextCancellationStopsIteration(t *testing.T) {
+	db := openTestDB(t)
+	for i := uint32(1); i <= 10; i++ {
+		require.NoError(t, db.StoreEvent(makeQuTransferEvent(t, i*10, uint64(i), 0, true)))
+	}
+
+	pub := kafka.NewMockPublisher()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel before the run
+
+	_, err := runReplay(ctx, db, pub, 0, 0, zap.NewNop())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Empty(t, pub.Messages(), "no batch should flush after immediate cancellation")
+}
+
+func TestRunReplay_PerTickBatching(t *testing.T) {
+	// Verify per-tick flush by tracking batch sizes — events on the same tick
+	// flush together; tick boundary causes a flush before the new tick events.
+	db := openTestDB(t)
+
+	require.NoError(t, db.StoreEvent(makeQuTransferEvent(t, 100, 1, 0, false)))
+	require.NoError(t, db.StoreEvent(makeQuTransferEvent(t, 100, 2, 1, false)))
+	require.NoError(t, db.StoreEvent(makeQuTransferEvent(t, 100, 3, 2, true)))
+	require.NoError(t, db.StoreEvent(makeQuTransferEvent(t, 200, 4, 0, true)))
+
+	pub := &batchTrackingPublisher{}
+	_, err := runReplay(context.Background(), db, pub, 0, 0, zap.NewNop())
+	require.NoError(t, err)
+
+	// Two flushes: one per tick.
+	assert.Equal(t, []int{3, 1}, pub.batchSizes)
+}
+
+// batchTrackingPublisher records the size of each PublishEvents call.
+type batchTrackingPublisher struct {
+	batchSizes []int
+}
+
+func (p *batchTrackingPublisher) PublishEvent(_ context.Context, _ *kafka.EventMessage) error {
+	return errors.New("not used")
+}
+
+func (p *batchTrackingPublisher) PublishEvents(_ context.Context, msgs []*kafka.EventMessage) error {
+	p.batchSizes = append(p.batchSizes, len(msgs))
+	return nil
+}
+
+func (p *batchTrackingPublisher) Close() error { return nil }

--- a/bob-events-bridge/internal/bob/websocket.go
+++ b/bob-events-bridge/internal/bob/websocket.go
@@ -91,7 +91,9 @@ func (c *WSClient) Subscribe(startTick uint32) (string, error) {
 	}
 
 	c.logger.Info("Sent tickStream subscription",
-		zap.Uint32("startTick", startTick))
+		zap.Uint32("startTick", startTick),
+		zap.Bool("excludeTxs", params.ExcludeTxs),
+		zap.Bool("skipEmptyTicks", params.SkipEmptyTicks))
 
 	// Read messages until we find the JSON-RPC response with our request ID.
 	// Bob may send tickStream notifications before the subscribe response

--- a/bob-events-bridge/internal/config/config.go
+++ b/bob-events-bridge/internal/config/config.go
@@ -22,6 +22,7 @@ type Config struct {
 	Server  ServerConfig
 	Kafka   KafkaConfig
 	Metrics MetricsConfig
+	Replay  ReplayConfig
 	Debug   bool `conf:"default:false,help:enable debug logging"`
 }
 
@@ -35,7 +36,8 @@ type BobConfig struct {
 
 // StorageConfig holds the storage configuration
 type StorageConfig struct {
-	BasePath string `conf:"default:data/bob-events-bridge,help:base path for data storage"`
+	BasePath   string `conf:"default:data/bob-events-bridge,help:base path for data storage"`
+	KeepEpochs uint16 `conf:"default:0,help:max number of recent epoch DBs to keep loaded (0 = unlimited; on retention, older DBs are unloaded but their directories are preserved on disk for external archival)"`
 }
 
 // ServerConfig holds the server configuration
@@ -55,6 +57,17 @@ type KafkaConfig struct {
 type MetricsConfig struct {
 	Port      int    `conf:"default:9999"`
 	Namespace string `conf:"default:qubic_events_bridge"`
+}
+
+// ReplayConfig holds the replay binary configuration.
+// Source DB path: <Storage.BasePath>/epochs/<Epoch>.
+// TickStart=0 means start of epoch; TickEnd=0 means end of epoch.
+type ReplayConfig struct {
+	EnableServer  bool   `conf:"default:false,help:serve gRPC/HTTP API from the loaded epoch DBs"`
+	EnablePublish bool   `conf:"default:false,help:publish events from a single epoch to Kafka and exit (requires Kafka.Enabled=true)"`
+	Epoch         uint16 `conf:"default:0,help:epoch to replay (required when EnablePublish=true)"`
+	TickStart     uint32 `conf:"default:0,help:first tick to publish (0 = start of epoch)"`
+	TickEnd       uint32 `conf:"default:0,help:last tick to publish (0 = end of epoch)"`
 }
 
 // Parse loads configuration from environment variables and CLI flags

--- a/bob-events-bridge/internal/e2e/e2e_test.go
+++ b/bob-events-bridge/internal/e2e/e2e_test.go
@@ -53,7 +53,7 @@ func TestE2E_SingleEventFlow(t *testing.T) {
 
 	// 2. Create storage
 	tempDir := t.TempDir()
-	storageMgr, err := storage.NewManager(tempDir, zap.NewNop())
+	storageMgr, err := storage.NewManager(tempDir, 0, zap.NewNop())
 	require.NoError(t, err, "Failed to create storage manager")
 
 	// 3. Create processor
@@ -115,7 +115,7 @@ func TestE2E_MultipleEventsPerTick(t *testing.T) {
 	defer mockBob.Close()
 
 	tempDir := t.TempDir()
-	storageMgr, err := storage.NewManager(tempDir, zap.NewNop())
+	storageMgr, err := storage.NewManager(tempDir, 0, zap.NewNop())
 	require.NoError(t, err)
 
 	cfg := CreateTestConfig(mockBob, tempDir)
@@ -186,7 +186,7 @@ func TestE2E_EpochTransition(t *testing.T) {
 	defer mockBob.Close()
 
 	tempDir := t.TempDir()
-	storageMgr, err := storage.NewManager(tempDir, zap.NewNop())
+	storageMgr, err := storage.NewManager(tempDir, 0, zap.NewNop())
 	require.NoError(t, err)
 
 	cfg := CreateTestConfig(mockBob, tempDir)
@@ -260,7 +260,7 @@ func TestE2E_EventOverwrite(t *testing.T) {
 	defer mockBob.Close()
 
 	tempDir := t.TempDir()
-	storageMgr, err := storage.NewManager(tempDir, zap.NewNop())
+	storageMgr, err := storage.NewManager(tempDir, 0, zap.NewNop())
 	require.NoError(t, err)
 
 	cfg := CreateTestConfig(mockBob, tempDir)
@@ -327,7 +327,7 @@ func TestE2E_StatePersistence(t *testing.T) {
 	defer mockBob.Close()
 
 	tempDir := t.TempDir()
-	storageMgr, err := storage.NewManager(tempDir, zap.NewNop())
+	storageMgr, err := storage.NewManager(tempDir, 0, zap.NewNop())
 	require.NoError(t, err)
 
 	cfg := CreateTestConfig(mockBob, tempDir)
@@ -380,7 +380,7 @@ func TestE2E_CrashRecovery(t *testing.T) {
 		mockBob := NewMockBobServer(145, 22000000)
 		defer mockBob.Close()
 
-		storageMgr, err := storage.NewManager(tempDir, zap.NewNop())
+		storageMgr, err := storage.NewManager(tempDir, 0, zap.NewNop())
 		require.NoError(t, err)
 
 		cfg := CreateTestConfig(mockBob, tempDir)
@@ -417,7 +417,7 @@ func TestE2E_CrashRecovery(t *testing.T) {
 	mockBob2 := NewMockBobServer(145, 22000100)
 	defer mockBob2.Close()
 
-	storageMgr2, err := storage.NewManager(tempDir, zap.NewNop())
+	storageMgr2, err := storage.NewManager(tempDir, 0, zap.NewNop())
 	require.NoError(t, err)
 
 	cfg2 := CreateTestConfig(mockBob2, tempDir)
@@ -449,7 +449,7 @@ func TestE2E_GetStatus(t *testing.T) {
 	defer mockBob.Close()
 
 	tempDir := t.TempDir()
-	storageMgr, err := storage.NewManager(tempDir, zap.NewNop())
+	storageMgr, err := storage.NewManager(tempDir, 0, zap.NewNop())
 	require.NoError(t, err)
 
 	cfg := CreateTestConfig(mockBob, tempDir)
@@ -510,7 +510,7 @@ func TestE2E_EventBodyParsing(t *testing.T) {
 	defer mockBob.Close()
 
 	tempDir := t.TempDir()
-	storageMgr, err := storage.NewManager(tempDir, zap.NewNop())
+	storageMgr, err := storage.NewManager(tempDir, 0, zap.NewNop())
 	require.NoError(t, err)
 
 	cfg := CreateTestConfig(mockBob, tempDir)
@@ -573,7 +573,7 @@ func TestE2E_QueryAssetOwnershipManagingContractChange(t *testing.T) {
 	defer mockBob.Close()
 
 	tempDir := t.TempDir()
-	storageMgr, err := storage.NewManager(tempDir, zap.NewNop())
+	storageMgr, err := storage.NewManager(tempDir, 0, zap.NewNop())
 	require.NoError(t, err)
 
 	cfg := CreateTestConfig(mockBob, tempDir)
@@ -639,7 +639,7 @@ func TestE2E_QueryAssetPossessionManagingContractChange(t *testing.T) {
 	defer mockBob.Close()
 
 	tempDir := t.TempDir()
-	storageMgr, err := storage.NewManager(tempDir, zap.NewNop())
+	storageMgr, err := storage.NewManager(tempDir, 0, zap.NewNop())
 	require.NoError(t, err)
 
 	cfg := CreateTestConfig(mockBob, tempDir)
@@ -707,7 +707,7 @@ func TestE2E_NonOKLogsSkipped(t *testing.T) {
 	defer mockBob.Close()
 
 	tempDir := t.TempDir()
-	storageMgr, err := storage.NewManager(tempDir, zap.NewNop())
+	storageMgr, err := storage.NewManager(tempDir, 0, zap.NewNop())
 	require.NoError(t, err)
 
 	cfg := CreateTestConfig(mockBob, tempDir)
@@ -773,7 +773,7 @@ func TestE2E_MultipleLogTypes(t *testing.T) {
 	defer mockBob.Close()
 
 	tempDir := t.TempDir()
-	storageMgr, err := storage.NewManager(tempDir, zap.NewNop())
+	storageMgr, err := storage.NewManager(tempDir, 0, zap.NewNop())
 	require.NoError(t, err)
 
 	cfg := CreateTestConfig(mockBob, tempDir)
@@ -834,7 +834,7 @@ func TestE2E_IndexInTickResetsAcrossTicks(t *testing.T) {
 	defer mockBob.Close()
 
 	tempDir := t.TempDir()
-	storageMgr, err := storage.NewManager(tempDir, zap.NewNop())
+	storageMgr, err := storage.NewManager(tempDir, 0, zap.NewNop())
 	require.NoError(t, err)
 
 	cfg := CreateTestConfig(mockBob, tempDir)
@@ -934,7 +934,7 @@ func TestE2E_CrashRecoveryIndexInTick(t *testing.T) {
 		mockBob := NewMockBobServer(145, 22000000)
 		defer mockBob.Close()
 
-		storageMgr, err := storage.NewManager(tempDir, zap.NewNop())
+		storageMgr, err := storage.NewManager(tempDir, 0, zap.NewNop())
 		require.NoError(t, err)
 
 		cfg := CreateTestConfig(mockBob, tempDir)
@@ -980,7 +980,7 @@ func TestE2E_CrashRecoveryIndexInTick(t *testing.T) {
 	mockBob2 := NewMockBobServer(145, 22000000)
 	defer mockBob2.Close()
 
-	storageMgr2, err := storage.NewManager(tempDir, zap.NewNop())
+	storageMgr2, err := storage.NewManager(tempDir, 0, zap.NewNop())
 	require.NoError(t, err)
 
 	cfg2 := CreateTestConfig(mockBob2, tempDir)
@@ -1048,7 +1048,7 @@ func TestE2E_KafkaPublishing(t *testing.T) {
 	defer mockBob.Close()
 
 	tempDir := t.TempDir()
-	storageMgr, err := storage.NewManager(tempDir, zap.NewNop())
+	storageMgr, err := storage.NewManager(tempDir, 0, zap.NewNop())
 	require.NoError(t, err)
 
 	mockKafka := kafka.NewMockPublisher()
@@ -1125,7 +1125,7 @@ func runLogTypeE2ETest(t *testing.T, tc logTypeTestCase) {
 	defer mockBob.Close()
 
 	tempDir := t.TempDir()
-	storageMgr, err := storage.NewManager(tempDir, zap.NewNop())
+	storageMgr, err := storage.NewManager(tempDir, 0, zap.NewNop())
 	require.NoError(t, err)
 
 	mockKafka := kafka.NewMockPublisher()
@@ -1573,7 +1573,7 @@ func TestE2E_KafkaPublishFailure(t *testing.T) {
 	defer mockBob.Close()
 
 	tempDir := t.TempDir()
-	storageMgr, err := storage.NewManager(tempDir, zap.NewNop())
+	storageMgr, err := storage.NewManager(tempDir, 0, zap.NewNop())
 	require.NoError(t, err)
 
 	mockKafka := kafka.NewMockPublisher()
@@ -1657,7 +1657,7 @@ func TestE2E_IndexResetAfterResend(t *testing.T) {
 		mockBob := NewMockBobServer(145, 22000000)
 		defer mockBob.Close()
 
-		storageMgr, err := storage.NewManager(tempDir, zap.NewNop())
+		storageMgr, err := storage.NewManager(tempDir, 0, zap.NewNop())
 		require.NoError(t, err)
 
 		mockKafka := kafka.NewMockPublisher()
@@ -1710,7 +1710,7 @@ func TestE2E_IndexResetAfterResend(t *testing.T) {
 	mockBob2 := NewMockBobServer(145, 22000000)
 	defer mockBob2.Close()
 
-	storageMgr2, err := storage.NewManager(tempDir, zap.NewNop())
+	storageMgr2, err := storage.NewManager(tempDir, 0, zap.NewNop())
 	require.NoError(t, err)
 
 	mockKafka2 := kafka.NewMockPublisher()
@@ -1840,7 +1840,7 @@ func TestE2E_NotificationsBeforeSubscribeResponse(t *testing.T) {
 	})
 
 	tempDir := t.TempDir()
-	storageMgr, err := storage.NewManager(tempDir, zap.NewNop())
+	storageMgr, err := storage.NewManager(tempDir, 0, zap.NewNop())
 	require.NoError(t, err)
 
 	cfg := CreateTestConfig(mockBob, tempDir)
@@ -1891,7 +1891,7 @@ func TestE2E_KafkaResend(t *testing.T) {
 		mockBob := NewMockBobServer(145, 22000000)
 		defer mockBob.Close()
 
-		storageMgr, err := storage.NewManager(tempDir, zap.NewNop())
+		storageMgr, err := storage.NewManager(tempDir, 0, zap.NewNop())
 		require.NoError(t, err)
 
 		mockKafka := kafka.NewMockPublisher()
@@ -1935,7 +1935,7 @@ func TestE2E_KafkaResend(t *testing.T) {
 	mockBob2 := NewMockBobServer(145, 22000000)
 	defer mockBob2.Close()
 
-	storageMgr2, err := storage.NewManager(tempDir, zap.NewNop())
+	storageMgr2, err := storage.NewManager(tempDir, 0, zap.NewNop())
 	require.NoError(t, err)
 
 	mockKafka2 := kafka.NewMockPublisher()

--- a/bob-events-bridge/internal/kafka/message_replay.go
+++ b/bob-events-bridge/internal/kafka/message_replay.go
@@ -1,0 +1,119 @@
+package kafka
+
+import (
+	"fmt"
+
+	eventsbridge "github.com/qubic/bob-events-bridge/api/events-bridge/v1"
+	"github.com/qubic/bob-events-bridge/internal/bob"
+)
+
+// TransformEventBodyMap mirrors TransformEventBody but operates on the
+// bob-format map[string]any read back from a stored proto Event (Body.AsMap()),
+// instead of a typed bob struct. The rename rules MUST stay in sync with
+// TransformEventBody — if you change one, change the other.
+func TransformEventBodyMap(eventType uint32, body map[string]any) (map[string]any, error) {
+	if body == nil {
+		return nil, nil
+	}
+
+	switch eventType {
+	case bob.LogTypeQuTransfer:
+		return map[string]any{
+			"source":      body["from"],
+			"destination": body["to"],
+			"amount":      body["amount"],
+		}, nil
+
+	case bob.LogTypeAssetIssuance:
+		return map[string]any{
+			"assetIssuer":           body["issuerPublicKey"],
+			"numberOfShares":        body["numberOfShares"],
+			"managingContractIndex": body["managingContractIndex"],
+			"assetName":             body["name"],
+			"numberOfDecimalPlaces": body["numberOfDecimalPlaces"],
+			"unitOfMeasurement":     body["unitOfMeasurement"],
+		}, nil
+
+	case bob.LogTypeAssetOwnershipChange, bob.LogTypeAssetPossessionChange:
+		return map[string]any{
+			"source":         body["sourcePublicKey"],
+			"destination":    body["destinationPublicKey"],
+			"assetIssuer":    body["issuerPublicKey"],
+			"assetName":      body["assetName"],
+			"numberOfShares": body["numberOfShares"],
+		}, nil
+
+	case bob.LogTypeBurning:
+		return map[string]any{
+			"source":                 body["publicKey"],
+			"amount":                 body["amount"],
+			"contractIndexBurnedFor": body["contractIndexBurnedFor"],
+		}, nil
+
+	case bob.LogTypeAssetOwnershipManagingContractChange:
+		return map[string]any{
+			"owner":                    body["ownershipPublicKey"],
+			"assetIssuer":              body["issuerPublicKey"],
+			"sourceContractIndex":      body["sourceContractIndex"],
+			"destinationContractIndex": body["destinationContractIndex"],
+			"numberOfShares":           body["numberOfShares"],
+			"assetName":                body["assetName"],
+		}, nil
+
+	case bob.LogTypeAssetPossessionManagingContractChange:
+		return map[string]any{
+			"possessor":                body["possessionPublicKey"],
+			"owner":                    body["ownershipPublicKey"],
+			"assetIssuer":              body["issuerPublicKey"],
+			"sourceContractIndex":      body["sourceContractIndex"],
+			"destinationContractIndex": body["destinationContractIndex"],
+			"numberOfShares":           body["numberOfShares"],
+			"assetName":                body["assetName"],
+		}, nil
+
+	// No-rename types: bob and kafka share the same field names.
+	case bob.LogTypeContractErrorMessage,
+		bob.LogTypeContractWarningMessage,
+		bob.LogTypeContractInformationMessage,
+		bob.LogTypeContractDebugMessage,
+		bob.LogTypeDustBurning,
+		bob.LogTypeSpectrumStats,
+		bob.LogTypeContractReserveDeduction,
+		bob.LogTypeOracleQueryStatusChange,
+		bob.LogTypeOracleSubscriberLogMessage,
+		bob.LogTypeCustomMessage:
+		return body, nil
+
+	default:
+		return nil, fmt.Errorf("unsupported event type for replay transform: %d", eventType)
+	}
+}
+
+// BuildEventMessageFromStored assembles a Kafka EventMessage from a stored proto Event.
+// Used by the replay path; mirrors BuildEventMessage on the live path.
+func BuildEventMessageFromStored(event *eventsbridge.Event) (*EventMessage, error) {
+	var bodyMap map[string]any
+	if event.Body != nil {
+		bodyMap = event.Body.AsMap()
+	}
+
+	transformed, err := TransformEventBodyMap(event.EventType, bodyMap)
+	if err != nil {
+		return nil, fmt.Errorf("failed to transform stored event body: %w", err)
+	}
+
+	return &EventMessage{
+		Index:      uint64(event.IndexInTick),
+		Type:       event.EventType,
+		TickNumber: event.Tick,
+		Epoch:      event.Epoch,
+		LogDigest:  event.LogDigest,
+		LogID:      event.LogId,
+		// Body size does not seem to be sent to elastic in the consumer, and we do not store it in the database.
+		BodySize:        0,
+		Timestamp:       event.Timestamp,
+		TransactionHash: event.TxHash,
+		Body:            transformed,
+		LastLogForTick:  event.LastLogForTick,
+	}, nil
+}

--- a/bob-events-bridge/internal/kafka/message_replay_test.go
+++ b/bob-events-bridge/internal/kafka/message_replay_test.go
@@ -1,0 +1,322 @@
+package kafka
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	eventsbridge "github.com/qubic/bob-events-bridge/api/events-bridge/v1"
+	"github.com/qubic/bob-events-bridge/internal/bob"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+func TestTransformEventBodyMap_QuTransfer(t *testing.T) {
+	body := map[string]any{
+		"from":   "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"to":     "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+		"amount": float64(1000),
+	}
+
+	result, err := TransformEventBodyMap(bob.LogTypeQuTransfer, body)
+	require.NoError(t, err)
+
+	expected := map[string]any{
+		"source":      "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"destination": "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+		"amount":      float64(1000),
+	}
+	if diff := cmp.Diff(expected, result); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestTransformEventBodyMap_AssetIssuance(t *testing.T) {
+	body := map[string]any{
+		"issuerPublicKey":       "ISSUERAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"numberOfShares":        float64(100000),
+		"managingContractIndex": float64(5),
+		"name":                  "QX",
+		"numberOfDecimalPlaces": float64(0),
+		"unitOfMeasurement":     "shares",
+	}
+
+	result, err := TransformEventBodyMap(bob.LogTypeAssetIssuance, body)
+	require.NoError(t, err)
+
+	expected := map[string]any{
+		"assetIssuer":           "ISSUERAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"assetName":             "QX",
+		"numberOfShares":        float64(100000),
+		"managingContractIndex": float64(5),
+		"numberOfDecimalPlaces": float64(0),
+		"unitOfMeasurement":     "shares",
+	}
+	if diff := cmp.Diff(expected, result); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestTransformEventBodyMap_AssetOwnershipChange(t *testing.T) {
+	body := map[string]any{
+		"sourcePublicKey":      "SRCAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"destinationPublicKey": "DSTAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"issuerPublicKey":      "ISSUERAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"assetName":            "QX",
+		"numberOfShares":       float64(500),
+	}
+
+	result, err := TransformEventBodyMap(bob.LogTypeAssetOwnershipChange, body)
+	require.NoError(t, err)
+
+	expected := map[string]any{
+		"source":         "SRCAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"destination":    "DSTAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"assetIssuer":    "ISSUERAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"assetName":      "QX",
+		"numberOfShares": float64(500),
+	}
+	if diff := cmp.Diff(expected, result); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestTransformEventBodyMap_AssetPossessionChange(t *testing.T) {
+	body := map[string]any{
+		"sourcePublicKey":      "SRCAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"destinationPublicKey": "DSTAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"issuerPublicKey":      "ISSUERAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"assetName":            "CFB",
+		"numberOfShares":       float64(200),
+	}
+
+	result, err := TransformEventBodyMap(bob.LogTypeAssetPossessionChange, body)
+	require.NoError(t, err)
+
+	expected := map[string]any{
+		"source":         "SRCAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"destination":    "DSTAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"assetIssuer":    "ISSUERAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"assetName":      "CFB",
+		"numberOfShares": float64(200),
+	}
+	if diff := cmp.Diff(expected, result); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestTransformEventBodyMap_Burning(t *testing.T) {
+	body := map[string]any{
+		"publicKey":              "BURNAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"amount":                 float64(999),
+		"contractIndexBurnedFor": float64(7),
+	}
+
+	result, err := TransformEventBodyMap(bob.LogTypeBurning, body)
+	require.NoError(t, err)
+
+	expected := map[string]any{
+		"source":                 "BURNAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"amount":                 float64(999),
+		"contractIndexBurnedFor": float64(7),
+	}
+	if diff := cmp.Diff(expected, result); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestTransformEventBodyMap_AssetOwnershipManagingContractChange(t *testing.T) {
+	body := map[string]any{
+		"ownershipPublicKey":       "OWNERAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"issuerPublicKey":          "ISSUERAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"sourceContractIndex":      float64(1),
+		"destinationContractIndex": float64(2),
+		"numberOfShares":           float64(500),
+		"assetName":                "QX",
+	}
+
+	result, err := TransformEventBodyMap(bob.LogTypeAssetOwnershipManagingContractChange, body)
+	require.NoError(t, err)
+
+	expected := map[string]any{
+		"owner":                    "OWNERAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"assetIssuer":              "ISSUERAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"sourceContractIndex":      float64(1),
+		"destinationContractIndex": float64(2),
+		"numberOfShares":           float64(500),
+		"assetName":                "QX",
+	}
+	if diff := cmp.Diff(expected, result); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestTransformEventBodyMap_AssetPossessionManagingContractChange(t *testing.T) {
+	body := map[string]any{
+		"possessionPublicKey":      "POSSESAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"ownershipPublicKey":       "OWNERAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"issuerPublicKey":          "ISSUERAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"sourceContractIndex":      float64(3),
+		"destinationContractIndex": float64(4),
+		"numberOfShares":           float64(750),
+		"assetName":                "CFB",
+	}
+
+	result, err := TransformEventBodyMap(bob.LogTypeAssetPossessionManagingContractChange, body)
+	require.NoError(t, err)
+
+	expected := map[string]any{
+		"possessor":                "POSSESAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"owner":                    "OWNERAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"assetIssuer":              "ISSUERAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"sourceContractIndex":      float64(3),
+		"destinationContractIndex": float64(4),
+		"numberOfShares":           float64(750),
+		"assetName":                "CFB",
+	}
+	if diff := cmp.Diff(expected, result); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestTransformEventBodyMap_NoRenamePassthrough(t *testing.T) {
+	cases := []struct {
+		name      string
+		eventType uint32
+		body      map[string]any
+	}{
+		{
+			name:      "ContractMessage",
+			eventType: bob.LogTypeContractErrorMessage,
+			body: map[string]any{
+				"scIndex":   float64(5),
+				"scLogType": float64(42),
+				"content":   "boom",
+			},
+		},
+		{
+			name:      "ContractReserveDeduction",
+			eventType: bob.LogTypeContractReserveDeduction,
+			body: map[string]any{
+				"deductedAmount":  float64(5000),
+				"remainingAmount": float64(95000),
+				"contractIndex":   float64(3),
+			},
+		},
+		{
+			name:      "DustBurningHex",
+			eventType: bob.LogTypeDustBurning,
+			body:      map[string]any{"hex": "deadbeef"},
+		},
+		{
+			name:      "OracleQueryStatusChange",
+			eventType: bob.LogTypeOracleQueryStatusChange,
+			body: map[string]any{
+				"queryingEntity": "QQQQQQ",
+				"queryId":        float64(123),
+				"interfaceIndex": float64(1),
+				"type":           float64(2),
+				"status":         "pending",
+			},
+		},
+		{
+			name:      "CustomMessage",
+			eventType: bob.LogTypeCustomMessage,
+			body:      map[string]any{"customMessage": "12345"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := TransformEventBodyMap(tc.eventType, tc.body)
+			require.NoError(t, err)
+			if diff := cmp.Diff(tc.body, result); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestTransformEventBodyMap_NilBody(t *testing.T) {
+	result, err := TransformEventBodyMap(bob.LogTypeQuTransfer, nil)
+	require.NoError(t, err)
+	assert.Nil(t, result)
+}
+
+func TestTransformEventBodyMap_UnsupportedType(t *testing.T) {
+	_, err := TransformEventBodyMap(999, map[string]any{"foo": "bar"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported event type")
+}
+
+func TestBuildEventMessageFromStored(t *testing.T) {
+	bodyStruct, err := structpb.NewStruct(map[string]any{
+		"from":   "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"to":     "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+		"amount": float64(1000),
+	})
+	require.NoError(t, err)
+
+	event := &eventsbridge.Event{
+		LogId:          42,
+		Tick:           22000001,
+		Epoch:          145,
+		EventType:      bob.LogTypeQuTransfer,
+		TxHash:         "TXHASH",
+		Timestamp:      1718461800,
+		Body:           bodyStruct,
+		IndexInTick:    3,
+		LogDigest:      "abc123",
+		LastLogForTick: true,
+	}
+
+	msg, err := BuildEventMessageFromStored(event)
+	require.NoError(t, err)
+
+	assert.Equal(t, uint64(3), msg.Index)
+	assert.Equal(t, bob.LogTypeQuTransfer, msg.Type)
+	assert.Equal(t, uint32(22000001), msg.TickNumber)
+	assert.Equal(t, uint32(145), msg.Epoch)
+	assert.Equal(t, "abc123", msg.LogDigest)
+	assert.Equal(t, uint64(42), msg.LogID)
+	assert.Equal(t, uint32(0), msg.BodySize, "BodySize must be 0 on replay (not stored in proto)")
+	assert.Equal(t, uint64(1718461800), msg.Timestamp)
+	assert.Equal(t, "TXHASH", msg.TransactionHash)
+	assert.True(t, msg.LastLogForTick)
+
+	require.NotNil(t, msg.Body)
+	assert.Equal(t, "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", msg.Body["source"])
+	assert.Equal(t, "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB", msg.Body["destination"])
+	assert.Equal(t, float64(1000), msg.Body["amount"])
+	assert.NotContains(t, msg.Body, "from", "from→source rename not applied")
+	assert.NotContains(t, msg.Body, "to", "to→destination rename not applied")
+}
+
+func TestBuildEventMessageFromStored_NilBody(t *testing.T) {
+	event := &eventsbridge.Event{
+		LogId:     1,
+		Tick:      100,
+		Epoch:     1,
+		EventType: bob.LogTypeQuTransfer,
+		Body:      nil,
+	}
+
+	msg, err := BuildEventMessageFromStored(event)
+	require.NoError(t, err)
+	assert.Nil(t, msg.Body)
+	assert.Equal(t, uint32(0), msg.BodySize)
+}
+
+func TestBuildEventMessageFromStored_UnsupportedTypePropagatesError(t *testing.T) {
+	bodyStruct, err := structpb.NewStruct(map[string]any{"foo": "bar"})
+	require.NoError(t, err)
+
+	event := &eventsbridge.Event{
+		EventType: 999,
+		Body:      bodyStruct,
+	}
+
+	_, err = BuildEventMessageFromStored(event)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to transform stored event body")
+}

--- a/bob-events-bridge/internal/kafka/publisher.go
+++ b/bob-events-bridge/internal/kafka/publisher.go
@@ -112,10 +112,9 @@ func (p *Producer) PublishEvents(ctx context.Context, msgs []*EventMessage) erro
 		p.metrics.IncPublisherMessagesPublished(msg.Type, p.topic)
 	}
 
-	p.logger.Info("Published batch to Kafka",
+	p.logger.Debug("Published batch to Kafka",
 		zap.Int("count", len(msgs)),
-		zap.Uint32("tick", msgs[0].TickNumber),
-		zap.String("topic", p.topic))
+		zap.Uint32("tick", msgs[0].TickNumber))
 
 	return nil
 }

--- a/bob-events-bridge/internal/kafka/publisher.go
+++ b/bob-events-bridge/internal/kafka/publisher.go
@@ -112,9 +112,10 @@ func (p *Producer) PublishEvents(ctx context.Context, msgs []*EventMessage) erro
 		p.metrics.IncPublisherMessagesPublished(msg.Type, p.topic)
 	}
 
-	p.logger.Debug("Published batch to Kafka",
+	p.logger.Info("Published batch to Kafka",
 		zap.Int("count", len(msgs)),
-		zap.Uint32("tick", msgs[0].TickNumber))
+		zap.Uint32("tick", msgs[0].TickNumber),
+		zap.String("topic", p.topic))
 
 	return nil
 }

--- a/bob-events-bridge/internal/processor/processor.go
+++ b/bob-events-bridge/internal/processor/processor.go
@@ -88,6 +88,7 @@ func (p *Processor) Start(ctx context.Context) error {
 				p.tickEventIndex = count
 				p.tickForIndex = state.LastTick
 				p.logger.Info("Recovered tick event index",
+					zap.Uint32("epoch", p.currentEpoch),
 					zap.Uint32("tick", state.LastTick),
 					zap.Uint32("tickEventIndex", p.tickEventIndex))
 			}
@@ -134,7 +135,9 @@ func (p *Processor) Start(ctx context.Context) error {
 			}
 
 			p.logger.Error("Processing error, will reconnect",
-				zap.Error(err))
+				zap.Error(err),
+				zap.Uint32("lastTick", p.lastTick),
+				zap.Uint32("currentEpoch", p.currentEpoch))
 
 			select {
 			case <-ctx.Done():
@@ -162,6 +165,11 @@ func (p *Processor) Stop() {
 
 // connectAndProcess handles a single connection session
 func (p *Processor) connectAndProcess(ctx context.Context) error {
+
+	p.logger.Info("Connecting to bob",
+		zap.String("url", p.cfg.Bob.WebSocketURL),
+		zap.Uint32("lastTick", p.lastTick),
+		zap.Uint32("currentEpoch", p.currentEpoch))
 
 	// Create WebSocket client
 	p.client = bob.NewWSClient(p.cfg.Bob.WebSocketURL, p.logger)
@@ -257,7 +265,10 @@ func (p *Processor) handleMessage(ctx context.Context, data []byte) error {
 			if err := p.flushBatch(ctx); err != nil {
 				return fmt.Errorf("failed to flush batch on catch-up complete: %w", err)
 			}
-			p.logger.Info("Catch-up complete")
+			p.logger.Info("Catch-up complete",
+				zap.Uint32("epoch", p.currentEpoch),
+				zap.Uint32("lastTick", p.lastTick),
+				zap.Uint64("totalEventsProcessed", p.eventsReceived))
 			return nil
 		}
 
@@ -287,7 +298,9 @@ func (p *Processor) handleTickStreamResult(ctx context.Context, result *bob.Tick
 		}
 		p.logger.Info("Epoch transition detected",
 			zap.Uint32("oldEpoch", p.currentEpoch),
-			zap.Uint16("newEpoch", result.Epoch))
+			zap.Uint16("newEpoch", result.Epoch),
+			zap.Uint32("tick", result.Tick),
+			zap.Uint64("totalEventsProcessed", p.eventsReceived))
 		p.currentEpoch = uint32(result.Epoch)
 		p.metrics.SetCurrentEpoch(result.Epoch)
 	}
@@ -456,10 +469,12 @@ func (p *Processor) flushBatch(ctx context.Context) error {
 	p.metrics.SetLastProcessedLogID(batch.lastLogID)
 	p.metrics.SetCurrentTickEventCount(0)
 
-	p.logger.Debug("Flushed batch",
+	p.logger.Info("Flushed batch",
 		zap.Uint32("tick", batch.tick),
 		zap.Uint32("epoch", batch.epoch),
-		zap.Int("events", len(batch.protoEvents)))
+		zap.Int("events", len(batch.protoEvents)),
+		zap.Uint64("lastLogID", batch.lastLogID),
+		zap.Uint64("totalEventsProcessed", p.eventsReceived))
 
 	return nil
 }

--- a/bob-events-bridge/internal/processor/processor_test.go
+++ b/bob-events-bridge/internal/processor/processor_test.go
@@ -48,7 +48,7 @@ func newTestProcessor(t *testing.T, publisher kafka.Publisher) *Processor {
 	t.Helper()
 	tempDir := t.TempDir()
 	logger := zap.NewNop()
-	mgr, err := storage.NewManager(tempDir, logger)
+	mgr, err := storage.NewManager(tempDir, 0, logger)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = mgr.Close() })
 

--- a/bob-events-bridge/internal/storage/epoch_db.go
+++ b/bob-events-bridge/internal/storage/epoch_db.go
@@ -136,6 +136,44 @@ func (e *EpochDB) CountEventsForTick(tick uint32) (uint32, error) {
 	return count, nil
 }
 
+// IterateEventsInRange invokes cb for every event in [tickStart, tickEnd] (inclusive),
+// in ascending key order. tickStart=0 means start of DB; tickEnd=0 means end of DB.
+// If cb returns an error, iteration stops and the error is returned.
+func (e *EpochDB) IterateEventsInRange(tickStart, tickEnd uint32, cb func(*eventsbridge.Event) error) error {
+	opts := &pebble.IterOptions{}
+	if tickStart > 0 {
+		opts.LowerBound = []byte(fmt.Sprintf("%010d:", tickStart))
+	}
+	if tickEnd > 0 {
+		// ';' is one greater than ':' in ASCII, so this excludes any keys past tickEnd.
+		opts.UpperBound = []byte(fmt.Sprintf("%010d;", tickEnd))
+	}
+
+	iter, err := e.db.NewIter(opts)
+	if err != nil {
+		return fmt.Errorf("failed to create iterator: %w", err)
+	}
+	defer iter.Close() //nolint:errcheck
+
+	for iter.First(); iter.Valid(); iter.Next() {
+		value, err := iter.ValueAndErr()
+		if err != nil {
+			return fmt.Errorf("failed to read value: %w", err)
+		}
+
+		event := &eventsbridge.Event{}
+		if err := proto.Unmarshal(value, event); err != nil {
+			return fmt.Errorf("failed to unmarshal event: %w", err)
+		}
+
+		if err := cb(event); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 // GetEventsForTick retrieves all events for a given tick using prefix scan
 func (e *EpochDB) GetEventsForTick(tick uint32) ([]*eventsbridge.Event, error) {
 	prefix := []byte(fmt.Sprintf("%010d:", tick))

--- a/bob-events-bridge/internal/storage/epoch_db.go
+++ b/bob-events-bridge/internal/storage/epoch_db.go
@@ -20,7 +20,7 @@ type EpochDB struct {
 func NewEpochDB(basePath string, epoch uint32) (*EpochDB, error) {
 	path := fmt.Sprintf("%s/epochs/%d", basePath, epoch)
 
-	db, err := pebble.Open(path, &pebble.Options{})
+	db, err := pebble.Open(path, tunedPebbleOptions(epoch))
 	if err != nil {
 		return nil, fmt.Errorf("failed to open epoch db: %w", err)
 	}

--- a/bob-events-bridge/internal/storage/epoch_db_test.go
+++ b/bob-events-bridge/internal/storage/epoch_db_test.go
@@ -1,0 +1,176 @@
+package storage
+
+import (
+	"errors"
+	"testing"
+
+	eventsbridge "github.com/qubic/bob-events-bridge/api/events-bridge/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func storeRange(t *testing.T, db *EpochDB, ticks []uint32, eventsPerTick int) {
+	t.Helper()
+	for _, tick := range ticks {
+		for i := 0; i < eventsPerTick; i++ {
+			ev := &eventsbridge.Event{
+				Epoch:     db.Epoch(),
+				Tick:      tick,
+				LogId:     uint64(tick)*100 + uint64(i),
+				EventType: 0,
+			}
+			require.NoError(t, db.StoreEvent(ev))
+		}
+	}
+}
+
+func collectTicks(events []*eventsbridge.Event) []uint32 {
+	out := make([]uint32, len(events))
+	for i, e := range events {
+		out[i] = e.Tick
+	}
+	return out
+}
+
+func TestIterateEventsInRange_Unbounded(t *testing.T) {
+	tempDir := t.TempDir()
+	db, err := NewEpochDB(tempDir, 1)
+	require.NoError(t, err)
+	defer db.Close() //nolint:errcheck
+
+	storeRange(t, db, []uint32{100, 200, 300}, 2)
+
+	var got []*eventsbridge.Event
+	err = db.IterateEventsInRange(0, 0, func(e *eventsbridge.Event) error {
+		got = append(got, e)
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Len(t, got, 6)
+	// Order is by tick-padded key, so ascending tick.
+	assert.Equal(t, []uint32{100, 100, 200, 200, 300, 300}, collectTicks(got))
+}
+
+func TestIterateEventsInRange_BoundedStart(t *testing.T) {
+	tempDir := t.TempDir()
+	db, err := NewEpochDB(tempDir, 1)
+	require.NoError(t, err)
+	defer db.Close() //nolint:errcheck
+
+	storeRange(t, db, []uint32{100, 200, 300}, 1)
+
+	var got []*eventsbridge.Event
+	err = db.IterateEventsInRange(200, 0, func(e *eventsbridge.Event) error {
+		got = append(got, e)
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []uint32{200, 300}, collectTicks(got))
+}
+
+func TestIterateEventsInRange_BoundedEnd(t *testing.T) {
+	tempDir := t.TempDir()
+	db, err := NewEpochDB(tempDir, 1)
+	require.NoError(t, err)
+	defer db.Close() //nolint:errcheck
+
+	storeRange(t, db, []uint32{100, 200, 300}, 1)
+
+	var got []*eventsbridge.Event
+	err = db.IterateEventsInRange(0, 200, func(e *eventsbridge.Event) error {
+		got = append(got, e)
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []uint32{100, 200}, collectTicks(got), "tickEnd is inclusive")
+}
+
+func TestIterateEventsInRange_BothBounds(t *testing.T) {
+	tempDir := t.TempDir()
+	db, err := NewEpochDB(tempDir, 1)
+	require.NoError(t, err)
+	defer db.Close() //nolint:errcheck
+
+	storeRange(t, db, []uint32{100, 150, 200, 250, 300}, 1)
+
+	var got []*eventsbridge.Event
+	err = db.IterateEventsInRange(150, 250, func(e *eventsbridge.Event) error {
+		got = append(got, e)
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []uint32{150, 200, 250}, collectTicks(got))
+}
+
+func TestIterateEventsInRange_ExactSingleTick(t *testing.T) {
+	tempDir := t.TempDir()
+	db, err := NewEpochDB(tempDir, 1)
+	require.NoError(t, err)
+	defer db.Close() //nolint:errcheck
+
+	storeRange(t, db, []uint32{100, 200, 300}, 3)
+
+	var got []*eventsbridge.Event
+	err = db.IterateEventsInRange(200, 200, func(e *eventsbridge.Event) error {
+		got = append(got, e)
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Len(t, got, 3)
+	for _, e := range got {
+		assert.Equal(t, uint32(200), e.Tick)
+	}
+}
+
+func TestIterateEventsInRange_EmptyRange(t *testing.T) {
+	tempDir := t.TempDir()
+	db, err := NewEpochDB(tempDir, 1)
+	require.NoError(t, err)
+	defer db.Close() //nolint:errcheck
+
+	storeRange(t, db, []uint32{100, 200}, 1)
+
+	var got []*eventsbridge.Event
+	err = db.IterateEventsInRange(500, 600, func(e *eventsbridge.Event) error {
+		got = append(got, e)
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+func TestIterateEventsInRange_EmptyDB(t *testing.T) {
+	tempDir := t.TempDir()
+	db, err := NewEpochDB(tempDir, 1)
+	require.NoError(t, err)
+	defer db.Close() //nolint:errcheck
+
+	called := false
+	err = db.IterateEventsInRange(0, 0, func(_ *eventsbridge.Event) error {
+		called = true
+		return nil
+	})
+	require.NoError(t, err)
+	assert.False(t, called)
+}
+
+func TestIterateEventsInRange_CallbackErrorStopsIteration(t *testing.T) {
+	tempDir := t.TempDir()
+	db, err := NewEpochDB(tempDir, 1)
+	require.NoError(t, err)
+	defer db.Close() //nolint:errcheck
+
+	storeRange(t, db, []uint32{100, 200, 300}, 1)
+
+	stopErr := errors.New("stop here")
+	count := 0
+	err = db.IterateEventsInRange(0, 0, func(_ *eventsbridge.Event) error {
+		count++
+		if count == 2 {
+			return stopErr
+		}
+		return nil
+	})
+	require.ErrorIs(t, err, stopErr)
+	assert.Equal(t, 2, count, "iteration must stop on callback error")
+}

--- a/bob-events-bridge/internal/storage/event_listener.go
+++ b/bob-events-bridge/internal/storage/event_listener.go
@@ -1,0 +1,61 @@
+package storage
+
+import (
+	"log"
+
+	"github.com/cockroachdb/pebble"
+)
+
+type PebbleEventListener struct {
+	pebble.EventListener
+
+	epoch uint32
+}
+
+func NewPebbleEventListener(epoch uint32) *PebbleEventListener {
+	l := &PebbleEventListener{epoch: epoch}
+	l.BackgroundError = l.backgroundError
+	l.CompactionBegin = l.compactionBegin
+	l.CompactionEnd = l.compactionEnd
+	l.FlushBegin = l.flushBegin
+	l.FlushEnd = l.flushEnd
+	l.WriteStallBegin = l.writeStallBegin
+	l.WriteStallEnd = l.writeStallEnd
+	return l
+}
+
+func (l *PebbleEventListener) backgroundError(err error) {
+
+	log.Printf("[PEBBLE-EP%d]: Encountered background error: %v", l.epoch, err)
+
+}
+
+func (l *PebbleEventListener) compactionBegin(info pebble.CompactionInfo) {
+
+	log.Printf("[PEBBLE-EP%d]: Compaction triggered. JobID: %d. Reason: %s. ", l.epoch, info.JobID, info.Reason)
+	for _, level := range info.Input {
+		log.Printf("  From Level %d - %s", level.Level, level.String())
+	}
+	log.Printf("  To level %d %ss", info.Output.Level, info.Output.String())
+
+}
+
+func (l *PebbleEventListener) compactionEnd(info pebble.CompactionInfo) {
+	log.Printf("[PEBBLE-EP%d]: Compaction with JobID %d ended. Took %v.", l.epoch, info.JobID, info.TotalDuration)
+}
+
+func (l *PebbleEventListener) flushBegin(info pebble.FlushInfo) {
+	log.Printf("[PEBBLE-EP%d]: Flush triggered. JobID: %d. Reason: %s.", l.epoch, info.JobID, info.Reason)
+}
+
+func (l *PebbleEventListener) flushEnd(info pebble.FlushInfo) {
+	log.Printf("[PEBBLE-EP%d]: Flush with JobID %d ended. Took %v.", l.epoch, info.JobID, info.TotalDuration)
+}
+
+func (l *PebbleEventListener) writeStallBegin(info pebble.WriteStallBeginInfo) {
+	log.Printf("[PEBBLE-EP%d]: Writes stalled. Reason: %s.", l.epoch, info.Reason)
+}
+
+func (l *PebbleEventListener) writeStallEnd() {
+	log.Printf("[PEBBLE-EP%d]: Writes resumed.", l.epoch)
+}

--- a/bob-events-bridge/internal/storage/manager.go
+++ b/bob-events-bridge/internal/storage/manager.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -12,17 +13,32 @@ import (
 	"go.uber.org/zap"
 )
 
+// ErrEpochOutOfScope is returned when a write is attempted for an epoch that
+// has been unloaded by retention (either skipped at startup discovery or
+// evicted during a runtime epoch transition). Out-of-scope is permanent for
+// the lifetime of the process; callers should treat this as a fatal condition
+// since it indicates either operator error (restored archive in live data dir,
+// misconfigured KeepEpochs) or unexpected ingest order.
+var ErrEpochOutOfScope = errors.New("storage: epoch is out of scope (below retention threshold)")
+
 // Manager manages multiple epoch databases
 type Manager struct {
-	basePath string
-	logger   *zap.Logger
-	state    *StateStore
-	epochDBs map[uint32]*EpochDB
-	mu       sync.RWMutex
+	basePath   string
+	keepEpochs uint16
+	logger     *zap.Logger
+	state      *StateStore
+	epochDBs   map[uint32]*EpochDB
+	// highestEvictedEpoch is the largest epoch number that has been unloaded
+	// by retention. Writes to epoch <= this value are rejected with
+	// ErrEpochOutOfScope. Process-lifetime only; rebuilt at startup from
+	// directories we found on disk but did not load.
+	highestEvictedEpoch uint32
+	mu                  sync.RWMutex
 }
 
-// NewManager creates a new storage manager
-func NewManager(basePath string, logger *zap.Logger) (*Manager, error) {
+// NewManager creates a new storage manager. keepEpochs caps the number of
+// recent epoch DBs kept loaded; 0 means unlimited (no eviction).
+func NewManager(basePath string, keepEpochs uint16, logger *zap.Logger) (*Manager, error) {
 	// Ensure base path exists
 	if err := os.MkdirAll(basePath, 0755); err != nil {
 		return nil, fmt.Errorf("failed to create base path: %w", err)
@@ -35,10 +51,11 @@ func NewManager(basePath string, logger *zap.Logger) (*Manager, error) {
 	}
 
 	m := &Manager{
-		basePath: basePath,
-		logger:   logger,
-		state:    state,
-		epochDBs: make(map[uint32]*EpochDB),
+		basePath:   basePath,
+		keepEpochs: keepEpochs,
+		logger:     logger,
+		state:      state,
+		epochDBs:   make(map[uint32]*EpochDB),
 	}
 
 	// Discover and open existing epoch databases
@@ -50,7 +67,11 @@ func NewManager(basePath string, logger *zap.Logger) (*Manager, error) {
 	return m, nil
 }
 
-// discoverEpochDBs scans the epochs subfolder for existing epoch databases
+// discoverEpochDBs scans the epochs subfolder for existing epoch databases.
+// If keepEpochs > 0, only the top-N epoch directories (by number) are opened;
+// the rest are left on disk for external archival and the highestEvictedEpoch
+// threshold is set to the largest skipped epoch so future writes for those
+// epochs are rejected with ErrEpochOutOfScope.
 func (m *Manager) discoverEpochDBs() error {
 	epochsPath := filepath.Join(m.basePath, "epochs")
 
@@ -65,28 +86,50 @@ func (m *Manager) discoverEpochDBs() error {
 		return fmt.Errorf("failed to read epochs path: %w", err)
 	}
 
+	// Collect all valid epoch numbers from disk.
+	found := make([]uint32, 0, len(entries))
 	for _, entry := range entries {
 		if !entry.IsDir() {
 			continue
 		}
-
-		name := entry.Name()
-		epoch, err := strconv.ParseUint(name, 10, 32)
+		epoch, err := strconv.ParseUint(entry.Name(), 10, 32)
 		if err != nil {
-			m.logger.Warn("Invalid epoch directory name", zap.String("name", name))
+			m.logger.Warn("Invalid epoch directory name", zap.String("name", entry.Name()))
 			continue
 		}
+		found = append(found, uint32(epoch))
+	}
 
-		db, err := NewEpochDB(m.basePath, uint32(epoch))
+	// Sort descending so we can take the top N.
+	sort.Slice(found, func(i, j int) bool { return found[i] > found[j] })
+
+	toOpen := found
+	var skipped []uint32
+	if m.keepEpochs > 0 && len(found) > int(m.keepEpochs) {
+		toOpen = found[:m.keepEpochs]
+		skipped = found[m.keepEpochs:]
+	}
+
+	for _, epoch := range toOpen {
+		db, err := NewEpochDB(m.basePath, epoch)
 		if err != nil {
 			m.logger.Error("Failed to open epoch db",
-				zap.Uint64("epoch", epoch),
+				zap.Uint32("epoch", epoch),
 				zap.Error(err))
 			continue
 		}
+		m.epochDBs[epoch] = db
+		m.logger.Info("Opened epoch database", zap.Uint32("epoch", epoch))
+	}
 
-		m.epochDBs[uint32(epoch)] = db
-		m.logger.Info("Opened epoch database", zap.Uint64("epoch", epoch))
+	// Set the out-of-scope threshold from the largest skipped epoch (if any).
+	// Skipped is sorted descending, so the first element is the max.
+	if len(skipped) > 0 {
+		m.highestEvictedEpoch = skipped[0]
+		for _, epoch := range skipped {
+			m.logger.Info("Epoch on disk but not loaded (retention)",
+				zap.Uint32("epoch", epoch))
+		}
 	}
 
 	return nil
@@ -121,13 +164,18 @@ func (m *Manager) LoadState() (*State, error) {
 	return m.state.LoadState()
 }
 
-// GetOrCreateEpochDB gets or creates an epoch database
+// GetOrCreateEpochDB gets or creates an epoch database.
+// Returns ErrEpochOutOfScope if the epoch has been unloaded by retention.
 func (m *Manager) GetOrCreateEpochDB(epoch uint32) (*EpochDB, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	if db, exists := m.epochDBs[epoch]; exists {
 		return db, nil
+	}
+
+	if m.keepEpochs > 0 && epoch <= m.highestEvictedEpoch {
+		return nil, fmt.Errorf("%w: epoch=%d threshold=%d", ErrEpochOutOfScope, epoch, m.highestEvictedEpoch)
 	}
 
 	db, err := NewEpochDB(m.basePath, epoch)
@@ -138,7 +186,46 @@ func (m *Manager) GetOrCreateEpochDB(epoch uint32) (*EpochDB, error) {
 	m.epochDBs[epoch] = db
 	m.logger.Info("Created new epoch database", zap.Uint32("epoch", epoch))
 
+	m.evictOldestIfOverLimit()
+
 	return db, nil
+}
+
+// evictOldestIfOverLimit unloads the oldest epoch DBs until len(epochDBs) <= keepEpochs.
+// Eviction = Close() + delete from map. The on-disk directory is left intact for
+// external archival. Caller must hold m.mu.
+func (m *Manager) evictOldestIfOverLimit() {
+	if m.keepEpochs == 0 {
+		return
+	}
+
+	for len(m.epochDBs) > int(m.keepEpochs) {
+		// Find the smallest epoch number currently loaded.
+		var oldest uint32
+		first := true
+		for e := range m.epochDBs {
+			if first || e < oldest {
+				oldest = e
+				first = false
+			}
+		}
+
+		db := m.epochDBs[oldest]
+		if err := db.Close(); err != nil {
+			m.logger.Error("Failed to close evicted epoch db",
+				zap.Uint32("epoch", oldest),
+				zap.Error(err))
+		}
+		delete(m.epochDBs, oldest)
+
+		if oldest > m.highestEvictedEpoch {
+			m.highestEvictedEpoch = oldest
+		}
+
+		m.logger.Info("Epoch unloaded (retention)",
+			zap.Uint32("epoch", oldest),
+			zap.Uint32("threshold", m.highestEvictedEpoch))
+	}
 }
 
 // GetEpochDB gets an epoch database if it exists

--- a/bob-events-bridge/internal/storage/manager_test.go
+++ b/bob-events-bridge/internal/storage/manager_test.go
@@ -25,11 +25,21 @@ func createTestEvent(epoch, tick uint32, logID uint64) *eventsbridge.Event {
 	}
 }
 
-// createTestManager creates a manager with the given temp directory and no-op logger
+// createTestManager creates a manager with the given temp directory and no-op logger.
+// keepEpochs=0 means unlimited (no retention).
 func createTestManager(t *testing.T, basePath string) *Manager {
 	t.Helper()
 	logger := zap.NewNop()
-	manager, err := NewManager(basePath, logger)
+	manager, err := NewManager(basePath, 0, logger)
+	require.NoError(t, err, "Failed to create manager")
+	return manager
+}
+
+// createTestManagerWithKeep creates a manager with a specific keepEpochs cap.
+func createTestManagerWithKeep(t *testing.T, basePath string, keepEpochs uint16) *Manager {
+	t.Helper()
+	logger := zap.NewNop()
+	manager, err := NewManager(basePath, keepEpochs, logger)
 	require.NoError(t, err, "Failed to create manager")
 	return manager
 }

--- a/bob-events-bridge/internal/storage/pebble_options.go
+++ b/bob-events-bridge/internal/storage/pebble_options.go
@@ -2,27 +2,23 @@ package storage
 
 import "github.com/cockroachdb/pebble"
 
-// Tuned for append-only time-series ingest: memtable size matches L0 target
-// so each flush produces exactly one SST; uniform 64MB SSTs across all levels
-// (per RocksDB default: file size stays constant, level capacity grows
-// geometrically via LBaseMaxBytes × LevelMultiplier); Zstd only at the
-// bottommost level (per RocksDB tuning guide) — Pebble's dynamic level bytes
-// places ~90% of data at the bottom level, so Zstd applies to most of the DB.
 func tunedPebbleOptions(epoch uint32) *pebble.Options {
 	listener := NewPebbleEventListener(epoch)
-	return &pebble.Options{
+	options := &pebble.Options{
 		EventListener:            &listener.EventListener,
 		MemTableSize:             64 * 1024 * 1024,  // 64MB
 		LBaseMaxBytes:            512 * 1024 * 1024, // 512MB
 		MaxConcurrentCompactions: func() int { return 4 },
 		Levels: []pebble.LevelOptions{
-			{TargetFileSize: 64 * 1024 * 1024, Compression: pebble.SnappyCompression}, // L0 64MB
-			{TargetFileSize: 64 * 1024 * 1024, Compression: pebble.SnappyCompression}, // L1 64MB
-			{TargetFileSize: 64 * 1024 * 1024, Compression: pebble.SnappyCompression}, // L2 64MB
-			{TargetFileSize: 64 * 1024 * 1024, Compression: pebble.SnappyCompression}, // L3 64MB
-			{TargetFileSize: 64 * 1024 * 1024, Compression: pebble.SnappyCompression}, // L4 64MB
-			{TargetFileSize: 64 * 1024 * 1024, Compression: pebble.SnappyCompression}, // L5 64MB
-			{TargetFileSize: 64 * 1024 * 1024, Compression: pebble.ZstdCompression},   // L6 64MB
+			{TargetFileSize: 64 * 1024 * 1024, Compression: pebble.NoCompression},       // L0
+			{TargetFileSize: 128 * 1024 * 1024, Compression: pebble.SnappyCompression},  // L1
+			{TargetFileSize: 256 * 1024 * 1024, Compression: pebble.SnappyCompression},  // L2
+			{TargetFileSize: 512 * 1024 * 1024, Compression: pebble.SnappyCompression},  // L3
+			{TargetFileSize: 1024 * 1024 * 1024, Compression: pebble.SnappyCompression}, // L4
+			{TargetFileSize: 2048 * 1024 * 1024, Compression: pebble.SnappyCompression}, // L5
+			{TargetFileSize: 4096 * 1024 * 1024, Compression: pebble.ZstdCompression},   // L6
 		},
 	}
+
+	return options
 }

--- a/bob-events-bridge/internal/storage/pebble_options.go
+++ b/bob-events-bridge/internal/storage/pebble_options.go
@@ -1,0 +1,22 @@
+package storage
+
+import "github.com/cockroachdb/pebble"
+
+func tunedPebbleOptions(epoch uint32) *pebble.Options {
+	listener := NewPebbleEventListener(epoch)
+	return &pebble.Options{
+		EventListener:            &listener.EventListener,
+		MemTableSize:             64 * 1024 * 1024,  // 64MB
+		LBaseMaxBytes:            256 * 1024 * 1024, // 256MB
+		MaxConcurrentCompactions: func() int { return 4 },
+		Levels: []pebble.LevelOptions{
+			{TargetFileSize: 4 * 1024 * 1024, Compression: pebble.SnappyCompression},  // L0 4MB
+			{TargetFileSize: 8 * 1024 * 1024, Compression: pebble.SnappyCompression},  // L1 8MB
+			{TargetFileSize: 16 * 1024 * 1024, Compression: pebble.SnappyCompression}, // L2 16MB
+			{TargetFileSize: 32 * 1024 * 1024, Compression: pebble.SnappyCompression}, // L3 32MB
+			{TargetFileSize: 64 * 1024 * 1024, Compression: pebble.ZstdCompression},   // L4 64MB
+			{TargetFileSize: 128 * 1024 * 1024, Compression: pebble.ZstdCompression},  // L5 128MB
+			{TargetFileSize: 256 * 1024 * 1024, Compression: pebble.ZstdCompression},  // L6 256MB
+		},
+	}
+}

--- a/bob-events-bridge/internal/storage/pebble_options.go
+++ b/bob-events-bridge/internal/storage/pebble_options.go
@@ -2,21 +2,27 @@ package storage
 
 import "github.com/cockroachdb/pebble"
 
+// Tuned for append-only time-series ingest: memtable size matches L0 target
+// so each flush produces exactly one SST; uniform 64MB SSTs across all levels
+// (per RocksDB default: file size stays constant, level capacity grows
+// geometrically via LBaseMaxBytes × LevelMultiplier); Zstd only at the
+// bottommost level (per RocksDB tuning guide) — Pebble's dynamic level bytes
+// places ~90% of data at the bottom level, so Zstd applies to most of the DB.
 func tunedPebbleOptions(epoch uint32) *pebble.Options {
 	listener := NewPebbleEventListener(epoch)
 	return &pebble.Options{
 		EventListener:            &listener.EventListener,
 		MemTableSize:             64 * 1024 * 1024,  // 64MB
-		LBaseMaxBytes:            256 * 1024 * 1024, // 256MB
+		LBaseMaxBytes:            512 * 1024 * 1024, // 512MB
 		MaxConcurrentCompactions: func() int { return 4 },
 		Levels: []pebble.LevelOptions{
-			{TargetFileSize: 4 * 1024 * 1024, Compression: pebble.SnappyCompression},  // L0 4MB
-			{TargetFileSize: 8 * 1024 * 1024, Compression: pebble.SnappyCompression},  // L1 8MB
-			{TargetFileSize: 16 * 1024 * 1024, Compression: pebble.SnappyCompression}, // L2 16MB
-			{TargetFileSize: 32 * 1024 * 1024, Compression: pebble.SnappyCompression}, // L3 32MB
-			{TargetFileSize: 64 * 1024 * 1024, Compression: pebble.ZstdCompression},   // L4 64MB
-			{TargetFileSize: 128 * 1024 * 1024, Compression: pebble.ZstdCompression},  // L5 128MB
-			{TargetFileSize: 256 * 1024 * 1024, Compression: pebble.ZstdCompression},  // L6 256MB
+			{TargetFileSize: 64 * 1024 * 1024, Compression: pebble.SnappyCompression}, // L0 64MB
+			{TargetFileSize: 64 * 1024 * 1024, Compression: pebble.SnappyCompression}, // L1 64MB
+			{TargetFileSize: 64 * 1024 * 1024, Compression: pebble.SnappyCompression}, // L2 64MB
+			{TargetFileSize: 64 * 1024 * 1024, Compression: pebble.SnappyCompression}, // L3 64MB
+			{TargetFileSize: 64 * 1024 * 1024, Compression: pebble.SnappyCompression}, // L4 64MB
+			{TargetFileSize: 64 * 1024 * 1024, Compression: pebble.SnappyCompression}, // L5 64MB
+			{TargetFileSize: 64 * 1024 * 1024, Compression: pebble.ZstdCompression},   // L6 64MB
 		},
 	}
 }

--- a/bob-events-bridge/internal/storage/retention_test.go
+++ b/bob-events-bridge/internal/storage/retention_test.go
@@ -1,0 +1,189 @@
+package storage
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+
+	eventsbridge "github.com/qubic/bob-events-bridge/api/events-bridge/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// preCreateEpochDirs opens (and immediately closes) the given epoch DBs so
+// their directories exist on disk for a subsequent manager to discover.
+func preCreateEpochDirs(t *testing.T, basePath string, epochs ...uint32) {
+	t.Helper()
+	for _, e := range epochs {
+		db, err := NewEpochDB(basePath, e)
+		require.NoError(t, err)
+		require.NoError(t, db.Close())
+	}
+}
+
+func TestKeepEpochs_DiscoveryCapsAtN(t *testing.T) {
+	tempDir := t.TempDir()
+	preCreateEpochDirs(t, tempDir, 1, 2, 3, 4, 5)
+
+	mgr := createTestManagerWithKeep(t, tempDir, 3)
+	defer mgr.Close() //nolint:errcheck
+
+	// Top 3 epochs by number stay loaded.
+	assert.Equal(t, []uint32{3, 4, 5}, mgr.GetAvailableEpochs())
+
+	// Skipped epoch directories must still exist on disk.
+	assert.DirExists(t, filepath.Join(tempDir, "epochs", "1"))
+	assert.DirExists(t, filepath.Join(tempDir, "epochs", "2"))
+}
+
+func TestKeepEpochs_DiscoveryUnlimitedWhenZero(t *testing.T) {
+	tempDir := t.TempDir()
+	preCreateEpochDirs(t, tempDir, 1, 2, 3, 4, 5)
+
+	mgr := createTestManager(t, tempDir) // keepEpochs=0
+	defer mgr.Close()                    //nolint:errcheck
+
+	assert.Equal(t, []uint32{1, 2, 3, 4, 5}, mgr.GetAvailableEpochs())
+}
+
+func TestKeepEpochs_EvictionOnEpochTransition(t *testing.T) {
+	tempDir := t.TempDir()
+
+	mgr := createTestManagerWithKeep(t, tempDir, 3)
+	defer mgr.Close() //nolint:errcheck
+
+	// Fill epochs 1, 2, 3 — at the cap.
+	for epoch := uint32(1); epoch <= 3; epoch++ {
+		require.NoError(t, mgr.StoreEvent(createTestEvent(epoch, 100, uint64(epoch))))
+	}
+	assert.Equal(t, []uint32{1, 2, 3}, mgr.GetAvailableEpochs())
+
+	// New epoch arrives — oldest (epoch 1) must be evicted.
+	require.NoError(t, mgr.StoreEvent(createTestEvent(4, 100, 4)))
+
+	assert.Equal(t, []uint32{2, 3, 4}, mgr.GetAvailableEpochs())
+
+	// On-disk directory for evicted epoch must be preserved for archival.
+	assert.DirExists(t, filepath.Join(tempDir, "epochs", "1"),
+		"evicted epoch directory must be preserved on disk")
+}
+
+func TestKeepEpochs_StateStoreEntriesPersistAfterEviction(t *testing.T) {
+	tempDir := t.TempDir()
+
+	mgr := createTestManagerWithKeep(t, tempDir, 2)
+	defer mgr.Close() //nolint:errcheck
+
+	require.NoError(t, mgr.StoreEvent(createTestEvent(1, 100, 1)))
+	require.NoError(t, mgr.StoreEvent(createTestEvent(2, 100, 2)))
+	require.NoError(t, mgr.StoreEvent(createTestEvent(3, 100, 3))) // evicts 1
+
+	require.NotContains(t, mgr.GetAvailableEpochs(), uint32(1))
+
+	// State-store entries for the evicted epoch are intentionally left intact;
+	// they're inert because GetStatus iterates m.epochDBs only.
+	minTick, maxTick, exists, err := mgr.state.GetEpochTickRange(1)
+	require.NoError(t, err)
+	assert.True(t, exists, "state-store keys should persist after eviction (inert)")
+	assert.Equal(t, uint32(100), minTick)
+	assert.Equal(t, uint32(100), maxTick)
+
+	count, err := mgr.state.GetEpochEventCount(1)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(1), count)
+}
+
+func TestKeepEpochs_GetStatusOnlyShowsLoadedEpochs(t *testing.T) {
+	tempDir := t.TempDir()
+
+	mgr := createTestManagerWithKeep(t, tempDir, 2)
+	defer mgr.Close() //nolint:errcheck
+
+	require.NoError(t, mgr.StoreEvent(createTestEvent(1, 100, 1)))
+	require.NoError(t, mgr.StoreEvent(createTestEvent(2, 100, 2)))
+	require.NoError(t, mgr.StoreEvent(createTestEvent(3, 100, 3))) // evicts 1
+
+	resp, err := mgr.GetStatus()
+	require.NoError(t, err)
+
+	gotEpochs := make([]uint32, 0, len(resp.Epochs))
+	for _, info := range resp.Epochs {
+		gotEpochs = append(gotEpochs, info.Epoch)
+	}
+	assert.ElementsMatch(t, []uint32{2, 3}, gotEpochs,
+		"GetStatus must not surface evicted epochs even though state keys remain")
+}
+
+func TestKeepEpochs_StoreEventReturnsErrorForEvictedEpoch(t *testing.T) {
+	tempDir := t.TempDir()
+
+	mgr := createTestManagerWithKeep(t, tempDir, 2)
+	defer mgr.Close() //nolint:errcheck
+
+	require.NoError(t, mgr.StoreEvent(createTestEvent(1, 100, 1)))
+	require.NoError(t, mgr.StoreEvent(createTestEvent(2, 100, 2)))
+	require.NoError(t, mgr.StoreEvent(createTestEvent(3, 100, 3))) // evicts 1
+
+	// Attempt to write to the evicted epoch — must fail with ErrEpochOutOfScope.
+	err := mgr.StoreEvent(createTestEvent(1, 200, 99))
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrEpochOutOfScope),
+		"expected ErrEpochOutOfScope, got: %v", err)
+}
+
+func TestKeepEpochs_StartupSkippedEpochIsOutOfScope(t *testing.T) {
+	tempDir := t.TempDir()
+	preCreateEpochDirs(t, tempDir, 1, 2, 3, 4, 5)
+
+	mgr := createTestManagerWithKeep(t, tempDir, 3)
+	defer mgr.Close() //nolint:errcheck
+
+	require.Equal(t, []uint32{3, 4, 5}, mgr.GetAvailableEpochs())
+
+	// Threshold from discovery should reject writes to epoch 2 even though it
+	// was never opened in this process.
+	err := mgr.StoreEvent(createTestEvent(2, 100, 1))
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrEpochOutOfScope),
+		"expected ErrEpochOutOfScope for startup-skipped epoch, got: %v", err)
+
+	// Boundary epoch (= threshold) is also out of scope.
+	err = mgr.StoreEvent(createTestEvent(1, 100, 1))
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrEpochOutOfScope))
+}
+
+func TestKeepEpochs_ZeroDisablesEvictionAndGuard(t *testing.T) {
+	tempDir := t.TempDir()
+
+	mgr := createTestManager(t, tempDir) // keepEpochs=0
+	defer mgr.Close()                    //nolint:errcheck
+
+	for epoch := uint32(1); epoch <= 10; epoch++ {
+		require.NoError(t, mgr.StoreEvent(createTestEvent(epoch, 100, uint64(epoch))))
+	}
+
+	// All 10 stay loaded; no eviction.
+	available := mgr.GetAvailableEpochs()
+	assert.Len(t, available, 10)
+}
+
+func TestKeepEpochs_StoreEventsBatchAlsoGuarded(t *testing.T) {
+	tempDir := t.TempDir()
+
+	mgr := createTestManagerWithKeep(t, tempDir, 2)
+	defer mgr.Close() //nolint:errcheck
+
+	require.NoError(t, mgr.StoreEvent(createTestEvent(1, 100, 1)))
+	require.NoError(t, mgr.StoreEvent(createTestEvent(2, 100, 2)))
+	require.NoError(t, mgr.StoreEvent(createTestEvent(3, 100, 3))) // evicts 1
+
+	// Batch path must enforce the same guard.
+	batch := []*eventsbridge.Event{
+		createTestEvent(1, 200, 10),
+		createTestEvent(1, 200, 11),
+	}
+	err := mgr.StoreEvents(batch)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrEpochOutOfScope))
+}

--- a/log-events-consumer/consume/consume_batch_integration_test.go
+++ b/log-events-consumer/consume/consume_batch_integration_test.go
@@ -65,7 +65,12 @@ func TestConsumeBatch_Integration(t *testing.T) {
 			}
 
 			m := metrics.NewMetrics(fmt.Sprintf("test_integration_%d", i))
-			consumer := NewConsumer(mockKafka, mockElastic, &tickstore.NoOpStore{}, m, map[uint64][]int16{0: {0, 1, 2, 3, 4, 5, 6, 8, 11, 12, 13, 14, 15, 255}}, 100*time.Millisecond, 1000)
+			consumerOptions := ConsumerOptions{
+				SupportedEventLogTypes: map[uint64][]int16{0: {0, 1, 2, 3, 4, 5, 6, 8, 11, 12, 13, 14, 15, 255}},
+				PollInterval:           100 * time.Millisecond,
+				PollMaxRecords:         1000,
+			}
+			consumer := NewConsumer(mockKafka, mockElastic, &tickstore.NoOpStore{}, m, consumerOptions)
 
 			records, docs, err := consumer.consumeBatch(context.Background())
 			require.NoError(t, err)
@@ -138,7 +143,12 @@ func TestConsumeBatch_Filtered_Integration(t *testing.T) {
 			}
 
 			m := metrics.NewMetrics(fmt.Sprintf("test_filtered_integration_%d", i))
-			consumer := NewConsumer(mockKafka, mockElastic, &tickstore.NoOpStore{}, m, map[uint64][]int16{0: {0, 1, 2, 3, 8, 13}}, 100*time.Millisecond, 1000)
+			consumerOptions := ConsumerOptions{
+				SupportedEventLogTypes: map[uint64][]int16{0: {0, 1, 2, 3, 8, 13}},
+				PollInterval:           100 * time.Millisecond,
+				PollMaxRecords:         1000,
+			}
+			consumer := NewConsumer(mockKafka, mockElastic, &tickstore.NoOpStore{}, m, consumerOptions)
 
 			records, docs, err := consumer.consumeBatch(context.Background())
 			require.NoError(t, err)

--- a/log-events-consumer/consume/consume_batch_integration_test.go
+++ b/log-events-consumer/consume/consume_batch_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/qubic/log-events-consumer/elastic"
 	"github.com/qubic/log-events-consumer/metrics"
@@ -64,7 +65,7 @@ func TestConsumeBatch_Integration(t *testing.T) {
 			}
 
 			m := metrics.NewMetrics(fmt.Sprintf("test_integration_%d", i))
-			consumer := NewConsumer(mockKafka, mockElastic, &tickstore.NoOpStore{}, m, map[uint64][]int16{0: {0, 1, 2, 3, 4, 5, 6, 8, 11, 12, 13, 14, 15, 255}})
+			consumer := NewConsumer(mockKafka, mockElastic, &tickstore.NoOpStore{}, m, map[uint64][]int16{0: {0, 1, 2, 3, 4, 5, 6, 8, 11, 12, 13, 14, 15, 255}}, 100*time.Millisecond, 1000)
 
 			records, docs, err := consumer.consumeBatch(context.Background())
 			require.NoError(t, err)
@@ -137,7 +138,7 @@ func TestConsumeBatch_Filtered_Integration(t *testing.T) {
 			}
 
 			m := metrics.NewMetrics(fmt.Sprintf("test_filtered_integration_%d", i))
-			consumer := NewConsumer(mockKafka, mockElastic, &tickstore.NoOpStore{}, m, map[uint64][]int16{0: {0, 1, 2, 3, 8, 13}})
+			consumer := NewConsumer(mockKafka, mockElastic, &tickstore.NoOpStore{}, m, map[uint64][]int16{0: {0, 1, 2, 3, 8, 13}}, 100*time.Millisecond, 1000)
 
 			records, docs, err := consumer.consumeBatch(context.Background())
 			require.NoError(t, err)

--- a/log-events-consumer/consume/consumer.go
+++ b/log-events-consumer/consume/consumer.go
@@ -44,22 +44,26 @@ type Consumer struct {
 	tickStore         TickStore
 	consumeMetrics    *metrics.Metrics
 	supportedLogTypes map[uint64][]int16
+	pollInterval      time.Duration
+	pollMaxRecords    int
 	highestTick       uint32
 	currentEpoch      uint32
 }
 
-func NewConsumer(kafkaClient KafkaClient, elasticClient ElasticClient, tickStore TickStore, metrics *metrics.Metrics, supportedEventLogTypes map[uint64][]int16) *Consumer {
+func NewConsumer(kafkaClient KafkaClient, elasticClient ElasticClient, tickStore TickStore, metrics *metrics.Metrics, supportedEventLogTypes map[uint64][]int16, pollInterval time.Duration, pollMaxRecords int) *Consumer {
 	return &Consumer{
 		kafkaClient:       kafkaClient,
 		elasticClient:     elasticClient,
 		tickStore:         tickStore,
 		consumeMetrics:    metrics,
 		supportedLogTypes: supportedEventLogTypes,
+		pollInterval:      pollInterval,
+		pollMaxRecords:    pollMaxRecords,
 	}
 }
 
 func (c *Consumer) Consume(ctx context.Context) error {
-	ticker := time.Tick(100 * time.Millisecond)
+	ticker := time.Tick(c.pollInterval)
 	for range ticker {
 
 		select {
@@ -83,7 +87,7 @@ func (c *Consumer) Consume(ctx context.Context) error {
 
 func (c *Consumer) consumeBatch(ctx context.Context) (int, int, error) {
 	defer c.kafkaClient.AllowRebalance()
-	fetches := c.kafkaClient.PollRecords(ctx, 1000)
+	fetches := c.kafkaClient.PollRecords(ctx, c.pollMaxRecords)
 	if errors := fetches.Errors(); len(errors) > 0 {
 		for _, err := range errors {
 			log.Printf("Fetches error: %v", err)

--- a/log-events-consumer/consume/consumer.go
+++ b/log-events-consumer/consume/consumer.go
@@ -50,15 +50,21 @@ type Consumer struct {
 	currentEpoch      uint32
 }
 
-func NewConsumer(kafkaClient KafkaClient, elasticClient ElasticClient, tickStore TickStore, metrics *metrics.Metrics, supportedEventLogTypes map[uint64][]int16, pollInterval time.Duration, pollMaxRecords int) *Consumer {
+type ConsumerOptions struct {
+	SupportedEventLogTypes map[uint64][]int16
+	PollInterval           time.Duration
+	PollMaxRecords         int
+}
+
+func NewConsumer(kafkaClient KafkaClient, elasticClient ElasticClient, tickStore TickStore, metrics *metrics.Metrics, consumerOptions ConsumerOptions) *Consumer {
 	return &Consumer{
 		kafkaClient:       kafkaClient,
 		elasticClient:     elasticClient,
 		tickStore:         tickStore,
 		consumeMetrics:    metrics,
-		supportedLogTypes: supportedEventLogTypes,
-		pollInterval:      pollInterval,
-		pollMaxRecords:    pollMaxRecords,
+		supportedLogTypes: consumerOptions.SupportedEventLogTypes,
+		pollInterval:      consumerOptions.PollInterval,
+		pollMaxRecords:    consumerOptions.PollMaxRecords,
 	}
 }
 

--- a/log-events-consumer/consume/consumer_test.go
+++ b/log-events-consumer/consume/consumer_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/qubic/log-events-consumer/domain"
 	"github.com/qubic/log-events-consumer/elastic"
@@ -97,7 +98,7 @@ func TestConsumeBatch_Success(t *testing.T) {
 	}
 
 	m := metrics.NewMetrics("test_success")
-	consumer := NewConsumer(mockKafka, mockElastic, &tickstore.NoOpStore{}, m, map[uint64][]int16{0: {0, 1, 2, 3, 8, 13}})
+	consumer := NewConsumer(mockKafka, mockElastic, &tickstore.NoOpStore{}, m, map[uint64][]int16{0: {0, 1, 2, 3, 8, 13}}, 100*time.Millisecond, 1000)
 
 	_, count, err := consumer.consumeBatch(context.Background())
 
@@ -168,7 +169,7 @@ func TestConsumeBatch_EmptyBatch(t *testing.T) {
 
 	mockElastic := &mockElasticClient{}
 	m := metrics.NewMetrics("test_empty")
-	consumer := NewConsumer(mockKafka, mockElastic, &tickstore.NoOpStore{}, m, map[uint64][]int16{0: {0, 1, 2, 3, 8, 13}})
+	consumer := NewConsumer(mockKafka, mockElastic, &tickstore.NoOpStore{}, m, map[uint64][]int16{0: {0, 1, 2, 3, 8, 13}}, 100*time.Millisecond, 1000)
 
 	_, count, err := consumer.consumeBatch(context.Background())
 
@@ -207,7 +208,7 @@ func TestConsumeBatch_InvalidJSON(t *testing.T) {
 
 	mockElastic := &mockElasticClient{}
 	m := metrics.NewMetrics("test_invalid")
-	consumer := NewConsumer(mockKafka, mockElastic, &tickstore.NoOpStore{}, m, map[uint64][]int16{0: {0, 1, 2, 3, 8, 13}})
+	consumer := NewConsumer(mockKafka, mockElastic, &tickstore.NoOpStore{}, m, map[uint64][]int16{0: {0, 1, 2, 3, 8, 13}}, 100*time.Millisecond, 1000)
 
 	_, _, err := consumer.consumeBatch(context.Background())
 
@@ -257,7 +258,7 @@ func TestConsumeBatch_ConversionError(t *testing.T) {
 
 	mockElastic := &mockElasticClient{}
 	m := metrics.NewMetrics("test_conversion_error")
-	consumer := NewConsumer(mockKafka, mockElastic, &tickstore.NoOpStore{}, m, map[uint64][]int16{0: {0, 1, 2, 3, 8, 13}})
+	consumer := NewConsumer(mockKafka, mockElastic, &tickstore.NoOpStore{}, m, map[uint64][]int16{0: {0, 1, 2, 3, 8, 13}}, 100*time.Millisecond, 1000)
 
 	_, _, err := consumer.consumeBatch(context.Background())
 
@@ -310,7 +311,7 @@ func TestConsumeBatch_ElasticError(t *testing.T) {
 	}
 
 	m := metrics.NewMetrics("test_elastic_err")
-	consumer := NewConsumer(mockKafka, mockElastic, &tickstore.NoOpStore{}, m, map[uint64][]int16{0: {0, 1, 2, 3, 8, 13}})
+	consumer := NewConsumer(mockKafka, mockElastic, &tickstore.NoOpStore{}, m, map[uint64][]int16{0: {0, 1, 2, 3, 8, 13}}, 100*time.Millisecond, 1000)
 
 	_, _, err := consumer.consumeBatch(context.Background())
 
@@ -361,7 +362,7 @@ func TestConsumeBatch_CommitError(t *testing.T) {
 
 	mockElastic := &mockElasticClient{}
 	m := metrics.NewMetrics("test_commit_err")
-	consumer := NewConsumer(mockKafka, mockElastic, &tickstore.NoOpStore{}, m, map[uint64][]int16{0: {0, 1, 2, 3, 8, 13}})
+	consumer := NewConsumer(mockKafka, mockElastic, &tickstore.NoOpStore{}, m, map[uint64][]int16{0: {0, 1, 2, 3, 8, 13}}, 100*time.Millisecond, 1000)
 
 	_, _, err := consumer.consumeBatch(context.Background())
 
@@ -435,7 +436,7 @@ func TestConsumeBatch_MultipleRecords(t *testing.T) {
 	}
 
 	m := metrics.NewMetrics("test_multiple")
-	consumer := NewConsumer(mockKafka, mockElastic, &tickstore.NoOpStore{}, m, map[uint64][]int16{0: {0, 1, 2, 3, 8, 13}})
+	consumer := NewConsumer(mockKafka, mockElastic, &tickstore.NoOpStore{}, m, map[uint64][]int16{0: {0, 1, 2, 3, 8, 13}}, 100*time.Millisecond, 1000)
 
 	_, count, err := consumer.consumeBatch(context.Background())
 
@@ -465,7 +466,7 @@ func TestConsume_ContextCancellation(t *testing.T) {
 
 	mockElastic := &mockElasticClient{}
 	m := metrics.NewMetrics("test_context_cancel")
-	consumer := NewConsumer(mockKafka, mockElastic, &tickstore.NoOpStore{}, m, map[uint64][]int16{0: {0, 1, 2, 3, 8, 13}})
+	consumer := NewConsumer(mockKafka, mockElastic, &tickstore.NoOpStore{}, m, map[uint64][]int16{0: {0, 1, 2, 3, 8, 13}}, 100*time.Millisecond, 1000)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -660,7 +661,7 @@ func TestConsumeBatch_filterIfLogIsNotSupported(t *testing.T) {
 			}
 
 			m := metrics.NewMetrics("test_supported_filter_" + tt.name)
-			consumer := NewConsumer(mockKafka, mockElastic, &tickstore.NoOpStore{}, m, map[uint64][]int16{0: {0, 1, 2, 3, 4, 5, 6, 8, 13, 255}})
+			consumer := NewConsumer(mockKafka, mockElastic, &tickstore.NoOpStore{}, m, map[uint64][]int16{0: {0, 1, 2, 3, 4, 5, 6, 8, 13, 255}}, 100*time.Millisecond, 1000)
 
 			_, count, err := consumer.consumeBatch(context.Background())
 			if err != nil {
@@ -737,7 +738,7 @@ func TestConsumeBatch_FilterEmptyTransfers(t *testing.T) {
 	}
 
 	m := metrics.NewMetrics("test_filter")
-	consumer := NewConsumer(mockKafka, mockElastic, &tickstore.NoOpStore{}, m, map[uint64][]int16{0: {0, 1, 2, 3, 8, 13}})
+	consumer := NewConsumer(mockKafka, mockElastic, &tickstore.NoOpStore{}, m, map[uint64][]int16{0: {0, 1, 2, 3, 8, 13}}, 100*time.Millisecond, 1000)
 
 	_, count, err := consumer.consumeBatch(context.Background())
 
@@ -822,7 +823,7 @@ func TestConsumeBatch_IDUniqueness(t *testing.T) {
 	}
 
 	m := metrics.NewMetrics("test_id_uniqueness")
-	consumer := NewConsumer(mockKafka, mockElastic, &tickstore.NoOpStore{}, m, map[uint64][]int16{0: {0, 1, 2, 3, 8, 13}})
+	consumer := NewConsumer(mockKafka, mockElastic, &tickstore.NoOpStore{}, m, map[uint64][]int16{0: {0, 1, 2, 3, 8, 13}}, 100*time.Millisecond, 1000)
 
 	_, count, err := consumer.consumeBatch(context.Background())
 

--- a/log-events-consumer/consume/consumer_test.go
+++ b/log-events-consumer/consume/consumer_test.go
@@ -98,7 +98,12 @@ func TestConsumeBatch_Success(t *testing.T) {
 	}
 
 	m := metrics.NewMetrics("test_success")
-	consumer := NewConsumer(mockKafka, mockElastic, &tickstore.NoOpStore{}, m, map[uint64][]int16{0: {0, 1, 2, 3, 8, 13}}, 100*time.Millisecond, 1000)
+	consumerOptions := ConsumerOptions{
+		SupportedEventLogTypes: map[uint64][]int16{0: {0, 1, 2, 3, 8, 13}},
+		PollInterval:           100 * time.Millisecond,
+		PollMaxRecords:         1000,
+	}
+	consumer := NewConsumer(mockKafka, mockElastic, &tickstore.NoOpStore{}, m, consumerOptions)
 
 	_, count, err := consumer.consumeBatch(context.Background())
 
@@ -169,7 +174,12 @@ func TestConsumeBatch_EmptyBatch(t *testing.T) {
 
 	mockElastic := &mockElasticClient{}
 	m := metrics.NewMetrics("test_empty")
-	consumer := NewConsumer(mockKafka, mockElastic, &tickstore.NoOpStore{}, m, map[uint64][]int16{0: {0, 1, 2, 3, 8, 13}}, 100*time.Millisecond, 1000)
+	consumerOptions := ConsumerOptions{
+		SupportedEventLogTypes: map[uint64][]int16{0: {0, 1, 2, 3, 8, 13}},
+		PollInterval:           100 * time.Millisecond,
+		PollMaxRecords:         1000,
+	}
+	consumer := NewConsumer(mockKafka, mockElastic, &tickstore.NoOpStore{}, m, consumerOptions)
 
 	_, count, err := consumer.consumeBatch(context.Background())
 
@@ -208,7 +218,12 @@ func TestConsumeBatch_InvalidJSON(t *testing.T) {
 
 	mockElastic := &mockElasticClient{}
 	m := metrics.NewMetrics("test_invalid")
-	consumer := NewConsumer(mockKafka, mockElastic, &tickstore.NoOpStore{}, m, map[uint64][]int16{0: {0, 1, 2, 3, 8, 13}}, 100*time.Millisecond, 1000)
+	consumerOptions := ConsumerOptions{
+		SupportedEventLogTypes: map[uint64][]int16{0: {0, 1, 2, 3, 8, 13}},
+		PollInterval:           100 * time.Millisecond,
+		PollMaxRecords:         1000,
+	}
+	consumer := NewConsumer(mockKafka, mockElastic, &tickstore.NoOpStore{}, m, consumerOptions)
 
 	_, _, err := consumer.consumeBatch(context.Background())
 
@@ -258,7 +273,12 @@ func TestConsumeBatch_ConversionError(t *testing.T) {
 
 	mockElastic := &mockElasticClient{}
 	m := metrics.NewMetrics("test_conversion_error")
-	consumer := NewConsumer(mockKafka, mockElastic, &tickstore.NoOpStore{}, m, map[uint64][]int16{0: {0, 1, 2, 3, 8, 13}}, 100*time.Millisecond, 1000)
+	consumerOptions := ConsumerOptions{
+		SupportedEventLogTypes: map[uint64][]int16{0: {0, 1, 2, 3, 8, 13}},
+		PollInterval:           100 * time.Millisecond,
+		PollMaxRecords:         1000,
+	}
+	consumer := NewConsumer(mockKafka, mockElastic, &tickstore.NoOpStore{}, m, consumerOptions)
 
 	_, _, err := consumer.consumeBatch(context.Background())
 
@@ -311,7 +331,12 @@ func TestConsumeBatch_ElasticError(t *testing.T) {
 	}
 
 	m := metrics.NewMetrics("test_elastic_err")
-	consumer := NewConsumer(mockKafka, mockElastic, &tickstore.NoOpStore{}, m, map[uint64][]int16{0: {0, 1, 2, 3, 8, 13}}, 100*time.Millisecond, 1000)
+	consumerOptions := ConsumerOptions{
+		SupportedEventLogTypes: map[uint64][]int16{0: {0, 1, 2, 3, 8, 13}},
+		PollInterval:           100 * time.Millisecond,
+		PollMaxRecords:         1000,
+	}
+	consumer := NewConsumer(mockKafka, mockElastic, &tickstore.NoOpStore{}, m, consumerOptions)
 
 	_, _, err := consumer.consumeBatch(context.Background())
 
@@ -362,7 +387,12 @@ func TestConsumeBatch_CommitError(t *testing.T) {
 
 	mockElastic := &mockElasticClient{}
 	m := metrics.NewMetrics("test_commit_err")
-	consumer := NewConsumer(mockKafka, mockElastic, &tickstore.NoOpStore{}, m, map[uint64][]int16{0: {0, 1, 2, 3, 8, 13}}, 100*time.Millisecond, 1000)
+	consumerOptions := ConsumerOptions{
+		SupportedEventLogTypes: map[uint64][]int16{0: {0, 1, 2, 3, 8, 13}},
+		PollInterval:           100 * time.Millisecond,
+		PollMaxRecords:         1000,
+	}
+	consumer := NewConsumer(mockKafka, mockElastic, &tickstore.NoOpStore{}, m, consumerOptions)
 
 	_, _, err := consumer.consumeBatch(context.Background())
 
@@ -436,7 +466,12 @@ func TestConsumeBatch_MultipleRecords(t *testing.T) {
 	}
 
 	m := metrics.NewMetrics("test_multiple")
-	consumer := NewConsumer(mockKafka, mockElastic, &tickstore.NoOpStore{}, m, map[uint64][]int16{0: {0, 1, 2, 3, 8, 13}}, 100*time.Millisecond, 1000)
+	consumerOptions := ConsumerOptions{
+		SupportedEventLogTypes: map[uint64][]int16{0: {0, 1, 2, 3, 8, 13}},
+		PollInterval:           100 * time.Millisecond,
+		PollMaxRecords:         1000,
+	}
+	consumer := NewConsumer(mockKafka, mockElastic, &tickstore.NoOpStore{}, m, consumerOptions)
 
 	_, count, err := consumer.consumeBatch(context.Background())
 
@@ -466,7 +501,12 @@ func TestConsume_ContextCancellation(t *testing.T) {
 
 	mockElastic := &mockElasticClient{}
 	m := metrics.NewMetrics("test_context_cancel")
-	consumer := NewConsumer(mockKafka, mockElastic, &tickstore.NoOpStore{}, m, map[uint64][]int16{0: {0, 1, 2, 3, 8, 13}}, 100*time.Millisecond, 1000)
+	consumerOptions := ConsumerOptions{
+		SupportedEventLogTypes: map[uint64][]int16{0: {0, 1, 2, 3, 8, 13}},
+		PollInterval:           100 * time.Millisecond,
+		PollMaxRecords:         1000,
+	}
+	consumer := NewConsumer(mockKafka, mockElastic, &tickstore.NoOpStore{}, m, consumerOptions)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -661,7 +701,12 @@ func TestConsumeBatch_filterIfLogIsNotSupported(t *testing.T) {
 			}
 
 			m := metrics.NewMetrics("test_supported_filter_" + tt.name)
-			consumer := NewConsumer(mockKafka, mockElastic, &tickstore.NoOpStore{}, m, map[uint64][]int16{0: {0, 1, 2, 3, 4, 5, 6, 8, 13, 255}}, 100*time.Millisecond, 1000)
+			consumerOptions := ConsumerOptions{
+				SupportedEventLogTypes: map[uint64][]int16{0: {0, 1, 2, 3, 4, 5, 6, 8, 13, 255}},
+				PollInterval:           100 * time.Millisecond,
+				PollMaxRecords:         1000,
+			}
+			consumer := NewConsumer(mockKafka, mockElastic, &tickstore.NoOpStore{}, m, consumerOptions)
 
 			_, count, err := consumer.consumeBatch(context.Background())
 			if err != nil {
@@ -738,7 +783,12 @@ func TestConsumeBatch_FilterEmptyTransfers(t *testing.T) {
 	}
 
 	m := metrics.NewMetrics("test_filter")
-	consumer := NewConsumer(mockKafka, mockElastic, &tickstore.NoOpStore{}, m, map[uint64][]int16{0: {0, 1, 2, 3, 8, 13}}, 100*time.Millisecond, 1000)
+	consumerOptions := ConsumerOptions{
+		SupportedEventLogTypes: map[uint64][]int16{0: {0, 1, 2, 3, 8, 13}},
+		PollInterval:           100 * time.Millisecond,
+		PollMaxRecords:         1000,
+	}
+	consumer := NewConsumer(mockKafka, mockElastic, &tickstore.NoOpStore{}, m, consumerOptions)
 
 	_, count, err := consumer.consumeBatch(context.Background())
 
@@ -823,7 +873,12 @@ func TestConsumeBatch_IDUniqueness(t *testing.T) {
 	}
 
 	m := metrics.NewMetrics("test_id_uniqueness")
-	consumer := NewConsumer(mockKafka, mockElastic, &tickstore.NoOpStore{}, m, map[uint64][]int16{0: {0, 1, 2, 3, 8, 13}}, 100*time.Millisecond, 1000)
+	consumerOptions := ConsumerOptions{
+		SupportedEventLogTypes: map[uint64][]int16{0: {0, 1, 2, 3, 8, 13}},
+		PollInterval:           100 * time.Millisecond,
+		PollMaxRecords:         1000,
+	}
+	consumer := NewConsumer(mockKafka, mockElastic, &tickstore.NoOpStore{}, m, consumerOptions)
 
 	_, count, err := consumer.consumeBatch(context.Background())
 

--- a/log-events-consumer/main.go
+++ b/log-events-consumer/main.go
@@ -50,9 +50,13 @@ func run() error {
 			MaxRetries  int      `conf:"default:15"`
 		}
 		Broker struct {
-			BootstrapServers []string `conf:"default:localhost:9092"`
-			ConsumeTopic     string   `conf:"default:qubic-log-events-data"`
-			ConsumerGroup    string   `conf:"default:qubic-elastic"`
+			BootstrapServers       []string      `conf:"default:localhost:9092"`
+			ConsumeTopic           string        `conf:"default:qubic-log-events-data"`
+			ConsumerGroup          string        `conf:"default:qubic-elastic"`
+			PollInterval           time.Duration `conf:"default:100ms"`
+			PollMaxRecords         int           `conf:"default:4096"`
+			FetchMaxBytes          int           `conf:"default:52428800"` //franz-go: 50 MiB — per-broker fetch-response cap; peak consumer buffer ≈ brokers * this
+			FetchMaxPartitionBytes int           `conf:"default:1048576"`  //franz-go: 1 MiB — per-partition cap inside a fetch; usually the per-poll batch-size bottleneck
 		}
 		Redis struct {
 			SentinelHosts    []string      `conf:"default:localhost:26379"` // format: "host:port"
@@ -107,6 +111,8 @@ func run() error {
 		kgo.SeedBrokers(cfg.Broker.BootstrapServers...),
 		kgo.ConsumeTopics(cfg.Broker.ConsumeTopic),
 		kgo.ConsumerGroup(cfg.Broker.ConsumerGroup),
+		kgo.FetchMaxBytes(int32(cfg.Broker.FetchMaxBytes)),
+		kgo.FetchMaxPartitionBytes(int32(cfg.Broker.FetchMaxPartitionBytes)),
 		kgo.BlockRebalanceOnPoll(),
 		kgo.DisableAutoCommit(),
 		kgo.WithLogger(kgo.BasicLogger(os.Stdout, kgo.LogLevelInfo, nil)),
@@ -158,7 +164,7 @@ func run() error {
 	}
 
 	consumeMetrics := metrics.NewMetrics(cfg.Metrics.Namespace)
-	consumer := consume.NewConsumer(kafkaCl, elasticCl, tickStore, consumeMetrics, supportedTypes)
+	consumer := consume.NewConsumer(kafkaCl, elasticCl, tickStore, consumeMetrics, supportedTypes, cfg.Broker.PollInterval, cfg.Broker.PollMaxRecords)
 	procError := make(chan error, 1)
 
 	consumerCtx, consumerCtxCancel := context.WithCancel(context.Background())

--- a/log-events-consumer/main.go
+++ b/log-events-consumer/main.go
@@ -50,13 +50,11 @@ func run() error {
 			MaxRetries  int      `conf:"default:15"`
 		}
 		Broker struct {
-			BootstrapServers       []string      `conf:"default:localhost:9092"`
-			ConsumeTopic           string        `conf:"default:qubic-log-events-data"`
-			ConsumerGroup          string        `conf:"default:qubic-elastic"`
-			PollInterval           time.Duration `conf:"default:100ms"`
-			PollMaxRecords         int           `conf:"default:4096"`
-			FetchMaxBytes          int           `conf:"default:52428800"` //franz-go: 50 MiB — per-broker fetch-response cap; peak consumer buffer ≈ brokers * this
-			FetchMaxPartitionBytes int           `conf:"default:1048576"`  //franz-go: 1 MiB — per-partition cap inside a fetch; usually the per-poll batch-size bottleneck
+			BootstrapServers []string      `conf:"default:localhost:9092"`
+			ConsumeTopic     string        `conf:"default:qubic-log-events-data"`
+			ConsumerGroup    string        `conf:"default:qubic-elastic"`
+			PollInterval     time.Duration `conf:"default:100ms"`
+			PollMaxRecords   int           `conf:"default:4096"`
 		}
 		Redis struct {
 			SentinelHosts    []string      `conf:"default:localhost:26379"` // format: "host:port"
@@ -111,8 +109,6 @@ func run() error {
 		kgo.SeedBrokers(cfg.Broker.BootstrapServers...),
 		kgo.ConsumeTopics(cfg.Broker.ConsumeTopic),
 		kgo.ConsumerGroup(cfg.Broker.ConsumerGroup),
-		kgo.FetchMaxBytes(int32(cfg.Broker.FetchMaxBytes)),
-		kgo.FetchMaxPartitionBytes(int32(cfg.Broker.FetchMaxPartitionBytes)),
 		kgo.BlockRebalanceOnPoll(),
 		kgo.DisableAutoCommit(),
 		kgo.WithLogger(kgo.BasicLogger(os.Stdout, kgo.LogLevelInfo, nil)),
@@ -164,7 +160,12 @@ func run() error {
 	}
 
 	consumeMetrics := metrics.NewMetrics(cfg.Metrics.Namespace)
-	consumer := consume.NewConsumer(kafkaCl, elasticCl, tickStore, consumeMetrics, supportedTypes, cfg.Broker.PollInterval, cfg.Broker.PollMaxRecords)
+	consumerOptions := consume.ConsumerOptions{
+		SupportedEventLogTypes: supportedTypes,
+		PollInterval:           cfg.Broker.PollInterval,
+		PollMaxRecords:         cfg.Broker.PollMaxRecords,
+	}
+	consumer := consume.NewConsumer(kafkaCl, elasticCl, tickStore, consumeMetrics, consumerOptions)
 	procError := make(chan error, 1)
 
 	consumerCtx, consumerCtxCancel := context.WithCancel(context.Background())


### PR DESCRIPTION
This PR adds three independent capabilities to bob-events-bridge and tunes log-events-consumer:

  1. events-replay binary (cmd/events-replay/) - replays stored events from a single epoch DB to Kafka and/or serves the gRPC/HTTP API from existing on-disk DBs.
  2. Epoch retention (storage.Manager.keepEpochs) - caps the number of epoch DBs kept loaded; older DBs are unloaded but their directories are preserved on disk for archival.
  3. Pebble tuning + event listener - explicit per-level memtable / file-size / compression options and a log.Printf event listener.

  Plus: kafka consumer poll config, additional structured logging context, and CI/Dockerfile wiring for the new binary.