### PR TITLE
security: workflow hardening (CODEOWNERS + lint)

### DIFF
--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -1,0 +1,39 @@
+name: Lint workflows
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - '.github/actions/**'
+
+concurrency:
+  group: lint-workflows-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    name: actionlint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
+        with:
+          persist-credentials: false
+      - name: Run actionlint
+        uses: reviewdog/action-actionlint@50842263c20a7c46bd0065b9e624d3c569db061e  # v1.73.0
+        with:
+          fail_on_error: true
+
+  zizmor:
+    name: zizmor
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
+        with:
+          persist-credentials: false
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@6599ee8b7a49aef6a770f63d261d214911a7ce02  # v0.6.0
+        with:
+          persona: auditor


### PR DESCRIPTION
## What

Adds two files as part of the post-2026-07-13 workflow-hardening rollout:

- `.github/CODEOWNERS` — mandates workflow-security review on `.github/workflows/`, `.github/actions/`, `.github/CODEOWNERS`, and `.github/dependabot.yml`.
- `.github/workflows/lint-workflows.yml` — runs `actionlint` + `zizmor` on any PR that touches workflow files.

## Why

Preventive actions **#2** and **#5** from the [2026-07-13 post-mortem](../../qct/incidents/2026-07-13/post_mortem.md). Together they gate malicious workflow-file additions behind competent security review and catch a large class of insecure workflow patterns automatically.

## Follow-up

Preventive action **#3** — adding a least-privilege `permissions:` block to every existing workflow file in this repo — is a per-workflow manual task. See the [repo maintainer guide](../../qct/incidents/maintainer_guide_workflows.md). Once merged, `actionlint`/`zizmor` will flag workflows missing that block.

## Branch protection

Branch protection on the default branch will be updated separately (via `rollout.sh protect`) to require Code Owner review. Nothing to do in this PR for that.

---

🤖 Rolled out by `incidents/rollout/rollout.sh`.